### PR TITLE
configure: fix compiling error for lacking of AM_PROG_CC_C_O in confi…

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -63,6 +63,9 @@ LT_INIT
 # Checks for programs.
 AC_PROG_CC
 
+# For legacy reasons.
+AM_PROG_CC_C_O
+
 AC_CHECK_PROG(RPCGEN, rpcgen, yes, no)
 if test "x$RPCGEN" = "xno"; then
   AC_MSG_ERROR([rpcgen not found, needed for building])


### PR DESCRIPTION
…gure.ac

Added the AM_PROG_CC_C_O macro although it is obsolete since
automake 1.14. But as automake < 1.14 is still out there.

Signed-off-by: Xiubo Li <lixiubo@cmss.chinamobile.com>

Many thanks for your interest in improving gluster-block!

gluster-block does not use GitHub Pull-Requests. Instead, changes are reviewed
on the Gerrit instance of the Gluster Community at https://review.gluster.org

In order to send your changes for review, follow these steps:

1. login on https://review.gluster.org with your GitHub account
2. add a public ssh-key to your profile on https://review.gluster.org/#/settings/ssh-keys
3. add the Gerrit remote to your locally cloned git repository

   $ git remote add gerrit ssh://$USER@review.gluster.org/gluster-block.git

4. configure the commit hooks

   $ git review --setup

5. post your changes to Gerrit

   $ git review


You may need to install the 'git-review' package if 'git review' is not
available. Note that the hooks for the repository make sure to add a ChangeId
label in the commit messages. Gerrit uses the ChangeId to track single patches
and its updated versions.

If there are any troubles or difficulties with these instructions, please
contact us on gluster-devel@gluster.org or on Freenode IRC in the #gluster-dev
channel.
