### PR TITLE
Support building with new glibc versions

### DIFF
--- a/cli/Makefile.am
+++ b/cli/Makefile.am
@@ -2,11 +2,12 @@ sbin_PROGRAMS = gluster-block
 
 gluster_block_SOURCES = gluster-block.c
 
-gluster_block_LDADD = $(top_builddir)/rpc/libgbrpc.la                \
+gluster_block_LDADD = $(TIRPC_LIBS)                                  \
+											$(top_builddir)/rpc/libgbrpc.la                \
 											$(top_builddir)/utils/libgb.la
 
-gluster_block_CFLAGS = -DDATADIR=\"$(localstatedir)\"                \
-											 -I$(top_srcdir)/ -I$(top_srcdir)/utils/			 \
+gluster_block_CFLAGS = $(TIRPC_CFLAGS) -DDATADIR=\"$(localstatedir)\" \
+											 -I$(top_srcdir)/ -I$(top_srcdir)/utils/			  \
 											 -I$(top_srcdir)/rpc -I$(top_builddir)/rpc/rpcl
 
 DISTCLEANFILES = Makefile.in

--- a/cli/gluster-block.c
+++ b/cli/gluster-block.c
@@ -80,15 +80,18 @@ glusterBlockCliRPC_1(void *cobj, clioperations opt)
     goto out;
   }
 
+#if 0
   if ((sockfd = socket(AF_UNIX, SOCK_STREAM, 0)) < 0) {
     snprintf (errMsg, sizeof (errMsg), "%s: socket creation failed (%s)",
               GB_UNIX_ADDRESS, strerror (errno));
     goto out;
   }
+#endif
 
   saun.sun_family = AF_UNIX;
   GB_STRCPYSTATIC(saun.sun_path, GB_UNIX_ADDRESS);
 
+#if 0
   if (connect(sockfd, (struct sockaddr *) &saun,
               sizeof(struct sockaddr_un)) < 0) {
     if (errno == ENOENT || errno == ECONNREFUSED) {
@@ -100,6 +103,7 @@ glusterBlockCliRPC_1(void *cobj, clioperations opt)
     }
     goto out;
   }
+#endif
 
   clnt = clntunix_create((struct sockaddr_un *) &saun,
                          GLUSTER_BLOCK_CLI, GLUSTER_BLOCK_CLI_VERS,

--- a/configure.ac
+++ b/configure.ac
@@ -77,7 +77,7 @@ AC_CHECK_HEADERS([stdio.h stdlib.h string.h stdbool.h stddef.h \
                   unistd.h errno.h memory.h time.h             \
                   netdb.h netinet/in.h sys/socket.h            \
                   pthread.h uuid/uuid.h glusterfs/api/glfs.h   \
-                  rpc/pmap_clnt.h ])
+                  rpc/pmap_clnt.h rpc/rpc.h ])
 
 # Checks for libraries.
 # glusterfs-api versions have a prefix of "7."
@@ -90,6 +90,11 @@ PKG_CHECK_MODULES([JSONC], [json-c],,
                   [AC_MSG_ERROR([json-c library is required to build gluster-block])])
 AC_SUBST(JSONC_CFLAGS)
 AC_SUBST(JSONC_LIBS)
+
+PKG_CHECK_MODULES([TIRPC], [libtirpc],,
+                  [AC_MSG_ERROR([tirpc library is required to build gluster-block])])
+AC_SUBST(TIRPC_CFLAGS)
+AC_SUBST(TIRPC_LIBS)
 
 AC_CHECK_LIB([uuid], [uuid_generate], [UUID="-luuid"],
              AC_MSG_ERROR([uuid library is required to build gluster-block]))

--- a/daemon/Makefile.am
+++ b/daemon/Makefile.am
@@ -2,11 +2,13 @@ sbin_PROGRAMS = gluster-blockd
 
 gluster_blockd_SOURCES = gluster-blockd.c
 
-gluster_blockd_CFLAGS = $(GFAPI_CFLAGS) -DDATADIR=\"$(localstatedir)\"         \
+gluster_blockd_CFLAGS = $(GFAPI_CFLAGS) $(TIRPC_CFLAGS)                        \
+                        -DDATADIR=\"$(localstatedir)\"                         \
                         -I$(top_builddir)/ -I$(top_srcdir)/utils/              \
                         -I$(top_srcdir)/rpc -I$(top_builddir)/rpc/rpcl
 
-gluster_blockd_LDADD = $(PTHREAD) $(top_builddir)/rpc/libgbrpc.la              \
+gluster_blockd_LDADD = $(TIRPC_LIBS) $(PTHREAD)                                \
+                       $(top_builddir)/rpc/libgbrpc.la                         \
                        $(top_builddir)/utils/libgb.la
 
 DISTCLEANFILES = Makefile.in

--- a/daemon/gluster-blockd.c
+++ b/daemon/gluster-blockd.c
@@ -13,6 +13,7 @@
 # include  <dirent.h>
 # include  <sys/stat.h>
 # include  <pthread.h>
+# include  <rpc/rpc.h>
 # include  <rpc/pmap_clnt.h>
 # include  <signal.h>
 

--- a/gluster-block.spec.in
+++ b/gluster-block.spec.in
@@ -22,6 +22,7 @@ Source0:          @PACKAGE_NAME@-@PACKAGE_VERSION@.tar.gz
 
 BuildRequires:    pkgconfig(glusterfs-api)
 BuildRequires:    pkgconfig(json-c)
+BuildRequires:    pkgconfig(libtirpc)
 BuildRequires:    help2man >= 1.36
 %if ( 0%{?_with_systemd:1} )
 %{?systemd_requires}
@@ -86,6 +87,9 @@ rm -rf ${RPM_BUILD_ROOT}
      %attr(0644,-,-) %{_sharedstatedir}/gluster-block/gluster-block-caps.info
 
 %changelog
+* Fri Aug 10 2018 Niels de Vos <ndevos@redhat.com>
+- use the modern libtirpc package, will be removed from glibc
+
 * Tue Jul 17 2018 Prasanna Kumar Kalever <prasanna.kalever@redhat.com>
 - change install path for gluster-block-caps.info
 - add install details for wait-for-bricks.sh

--- a/gluster-block.spec.in
+++ b/gluster-block.spec.in
@@ -24,6 +24,9 @@ BuildRequires:    pkgconfig(glusterfs-api)
 BuildRequires:    pkgconfig(json-c)
 BuildRequires:    pkgconfig(libtirpc)
 BuildRequires:    help2man >= 1.36
+%if ( 0%{?fedora} && 0%{?fedora} >= 28 )
+BuildRequires:    rpcgen
+%endif
 %if ( 0%{?_with_systemd:1} )
 %{?systemd_requires}
 BuildRequires:    systemd
@@ -89,6 +92,7 @@ rm -rf ${RPM_BUILD_ROOT}
 %changelog
 * Fri Aug 10 2018 Niels de Vos <ndevos@redhat.com>
 - use the modern libtirpc package, will be removed from glibc
+- new Fedora releases require rpcgen (unbundled from glibc)
 
 * Tue Jul 17 2018 Prasanna Kumar Kalever <prasanna.kalever@redhat.com>
 - change install path for gluster-block-caps.info

--- a/gluster-block.spec.in
+++ b/gluster-block.spec.in
@@ -117,7 +117,7 @@ rm -rf ${RPM_BUILD_ROOT}
 * Fri Aug 11 2017 Prasanna Kumar Kalever <prasanna.kalever@redhat.com>
 - add wrapper target service unit
 
-* Tue Jun 22 2017 Prasanna Kumar Kalever <prasanna.kalever@redhat.com>
+* Thu Jun 22 2017 Prasanna Kumar Kalever <prasanna.kalever@redhat.com>
 - update with missing dependencies
 
 * Tue Jun 06 2017 Prasanna Kumar Kalever <prasanna.kalever@redhat.com>

--- a/rpc/Makefile.am
+++ b/rpc/Makefile.am
@@ -6,11 +6,12 @@ libgbrpc_la_SOURCES = block_svc_routines.c glfs-operations.c
 
 noinst_HEADERS = glfs-operations.h
 
-libgbrpc_la_CFLAGS = $(GFAPI_CFLAGS) $(JSONC_CFLAGS) \
+libgbrpc_la_CFLAGS = $(GFAPI_CFLAGS) $(JSONC_CFLAGS) $(TIRPC_CFLAGS) \
                        -DDATADIR=\"$(localstatedir)\"  \
                        -I$(top_srcdir)/utils/ -I$(top_builddir)/rpc/rpcl
 
-libgbrpc_la_LIBADD = $(GFAPI_LIBS) $(JSONC_LIBS) $(UUID) rpcl/libgbrpcxdr.la
+libgbrpc_la_LIBADD = $(GFAPI_LIBS) $(JSONC_LIBS) $(UUID) $(TIRPC_LIBS) \
+                     rpcl/libgbrpcxdr.la
 
 libgbrpc_ladir = $(includedir)/gluster-block/rpc
 

--- a/rpc/rpcl/Makefile.am
+++ b/rpc/rpcl/Makefile.am
@@ -1,4 +1,6 @@
 libgbrpcxdr_la_SOURCES = block_clnt.c block_xdr.c block_svc.c
+libgbrpcxdr_la_CFLAGS = $(TIRPC_CFLAGS)
+libgbrpcxdr_la_LDFLAGS = $(TIRPC_LIBS)
 
 noinst_LTLIBRARIES = libgbrpcxdr.la
 noinst_HEADERS = block.h block_svc.h rpc-pragmas.h

--- a/utils/Makefile.am
+++ b/utils/Makefile.am
@@ -4,11 +4,12 @@ libgb_la_SOURCES = common.c utils.c lru.c capabilities.c
 
 noinst_HEADERS = common.h utils.h lru.h list.h capabilities.h
 
-libgb_la_CFLAGS = $(GFAPI_CFLAGS) -DDATADIR=\"$(localstatedir)\"               \
+libgb_la_CFLAGS = $(GFAPI_CFLAGS) $(TIRPC_CFLAGS)                              \
+                  -DDATADIR=\"$(localstatedir)\"                               \
                   -DCONFDIR=\"$(GLUSTER_BLOCKD_WORKDIR)\"                      \
                   -I$(top_builddir)/ -I$(top_builddir)/rpc/rpcl
 
-libgb_la_LIBADD = $(GFAPI_LIBS)
+libgb_la_LIBADD = $(GFAPI_LIBS) $(TIRPC_LIBS)
 
 libgb_ladir = $(includedir)/gluster-block/utils
 


### PR DESCRIPTION
Fedora 28 uses a newer glibc version that does not contain the `rpcgen` tool and standard RPC/XDR/.. functions anymore. The modern way is to use the newly split `rpcgen` package as BuildRequires and the headers from `libtirpc-devel` with linking against `libtirpc.so`.

The two patches in this PR make building on Fedora 28 work again. Additional builds on earlier versions and in the CentOS Storage SIG have not been broken.

Except for building, nothing is tested (no easy way to run tests?).

Closes: #56