### PR TITLE
block: add support for serving storage objects via fuse (FileIO)

### DIFF
--- a/cli/gluster-block.c
+++ b/cli/gluster-block.c
@@ -15,9 +15,10 @@
 
 
 # define  GB_CREATE_HELP_STR  "gluster-block create <volname/blockname> "      \
-                                "[ha <count>] [auth <enable|disable>] "        \
-                                "[prealloc <full|no>] [storage <filename>] "   \
-                                "<HOST1[,HOST2,...]> <size> [--json*]"
+                                "[ha <count>] [type <glfs|fuse>] "             \
+                                "[auth <enable|disable>] [prealloc <full|no>] "\
+                                "[storage <filename>] <HOST1[,HOST2,...]> "    \
+                                "<size> [--json*]"
 # define  GB_DELETE_HELP_STR  "gluster-block delete <volname/blockname> "      \
                                 "[unlink-storage <yes|no>] [force] [--json*]"
 # define  GB_MODIFY_HELP_STR  "gluster-block modify <volname/blockname> "      \
@@ -200,11 +201,12 @@ glusterBlockHelp(void)
       "\n"
       "commands:\n"
       "  create  <volname/blockname> [ha <count>]\n"
+      "                              [type <glfs|fuse>\n"
       "                              [auth <enable|disable>]\n"
       "                              [prealloc <full|no>]\n"
       "                              [storage <filename>]\n"
       "                              <host1[,host2,...]> <size>\n"
-      "        create block device [defaults: ha 1, auth disable, prealloc no, size in bytes]\n"
+      "        create block device [defaults: ha 1, type glfs, auth disable, prealloc no, size in bytes]\n"
       "\n"
       "  list    <volname>\n"
       "        list available block devices.\n"
@@ -379,6 +381,20 @@ glusterBlockCreate(int argcount, char **options, int json)
     switch (glusterBlockCLICreateOptEnumParse(options[optind++])) {
     case GB_CLI_CREATE_HA:
       sscanf(options[optind++], "%u", &cobj.mpath);
+      break;
+    case GB_CLI_CREATE_TYPE:
+      ret = glusterBlockCLICreateTypeOptEnumParse(options[optind++]);
+      if (ret != GB_CLI_CREATE_TYPE_OPT_MAX) {
+        cobj.type = ret;
+        ret = 0;
+      } else {
+        MSG("%s\n", "'type' option is incorrect");
+        MSG("%s\n", GB_CREATE_HELP_STR);
+        LOG("cli", GB_LOG_ERROR, "Create failed while parsing argument "
+                                 "to type for <%s/%s>",
+                                 cobj.volume, cobj.block_name);
+        goto out;
+      }
       break;
     case GB_CLI_CREATE_AUTH:
       ret = convertStringToTrillianParse(options[optind++]);

--- a/rpc/glfs-operations.c
+++ b/rpc/glfs-operations.c
@@ -371,6 +371,9 @@ blockStuffMetaInfo(MetaInfo *info, char *line)
   case GB_META_PASSWD:
     GB_STRCPYSTATIC(info->passwd, strchr(line, ' ') + 1);
     break;
+  case GB_META_TYPE:
+    info->type = glusterBlockCLICreateTypeOptEnumParse(strchr(line, ' ') + 1);
+    break;
 
   default:
     if(!info->list) {

--- a/rpc/glfs-operations.h
+++ b/rpc/glfs-operations.h
@@ -32,6 +32,7 @@ typedef struct MetaInfo {
   char   gbid[38];
   size_t size;
   size_t mpath;
+  int    type;
   char   entry[16];  /* possible strings for ENTRYCREATE: INPROGRESS|SUCCESS|FAIL */
   char   passwd[38];
 

--- a/rpc/rpcl/block.x
+++ b/rpc/rpcl/block.x
@@ -23,6 +23,7 @@ struct blockCreate {
   char      block_name[255];
   string    block_hosts<>;               /* for multiple tpg's creation */
   bool      auth_mode;
+  u_int     type;
 };
 
 struct blockModify {
@@ -31,6 +32,7 @@ struct blockModify {
   char      gbid[127];
   char      passwd[127];
   bool      auth_mode;
+  u_int     type;
 };
 
 struct blockReplace {
@@ -45,6 +47,7 @@ struct blockCreateCli {
   char      volume[255];
   u_quad_t  size;
   u_int     mpath;                /* HA request count */
+  u_int     type;
   bool      auth_mode;
   bool      prealloc;
   char      storage[255];
@@ -64,6 +67,7 @@ struct blockDeleteCli {
 struct blockDelete {
   char      block_name[255];
   char      gbid[127];
+  u_int     type;
 };
 
 struct blockInfoCli {

--- a/utils/capabilities.h
+++ b/utils/capabilities.h
@@ -41,6 +41,8 @@ enum gbCapabilities {
 
   GB_JSON_CAP,
 
+  GB_CREATE_TYPE_CAP,
+
   GB_CAP_MAX
 };
 
@@ -60,6 +62,8 @@ static const char *const gbCapabilitiesLookup[] = {
   [GB_REPLACE_CAP]             = "replace",
 
   [GB_JSON_CAP]                = "json",
+
+  [GB_CREATE_TYPE_CAP]         = "create_type",
 
   [GB_CAP_MAX]                 = NULL
 };

--- a/utils/gluster-block-caps.info
+++ b/utils/gluster-block-caps.info
@@ -108,3 +108,15 @@ json: true
 # Since: 0.4
 ##
 replace: true
+
+
+##
+# Nature: cli sub command
+#
+# Label: 'type'
+#
+# Description: capability to create blocks from user handler and fileio
+#
+# Since: 0.4
+##
+create_type: true

--- a/utils/utils.c
+++ b/utils/utils.c
@@ -68,6 +68,24 @@ glusterBlockCLICreateOptEnumParse(const char *opt)
   return i;
 }
 
+int
+glusterBlockCLICreateTypeOptEnumParse(const char *opt)
+{
+  int i;
+
+
+  if (!opt) {
+    return GB_CLI_CREATE_TYPE_OPT_MAX;
+  }
+
+  for (i = 0; i < GB_CLI_CREATE_TYPE_OPT_MAX; i++) {
+    if (!strcmp(opt, gbCliCreateTypeOptLookup[i])) {
+      return i;
+    }
+  }
+
+  return i;
+}
 
 int
 glusterBlockDaemonOptEnumParse(const char *opt)

--- a/utils/utils.h
+++ b/utils/utils.h
@@ -28,6 +28,7 @@
 
 # define  GB_LOGDIR              DATADIR "/log/gluster-block"
 # define  GB_INFODIR             DATADIR "/run"
+# define  GB_FUSEDIR             GB_INFODIR "/gluster-block"
 
 # define  GB_LOCK_FILE           GB_INFODIR "/gluster-blockd.lock"
 # define  GB_UNIX_ADDRESS        GB_INFODIR "/gluster-blockd.socket"
@@ -380,6 +381,7 @@ typedef enum gbCliCreateOptions {
   GB_CLI_CREATE_AUTH      = 2,
   GB_CLI_CREATE_PREALLOC  = 3,
   GB_CLI_CREATE_STORAGE   = 4,
+  GB_CLI_CREATE_TYPE      = 5,
 
   GB_CLI_CREATE_OPT_MAX
 } gbCliCreateOptions;
@@ -390,8 +392,24 @@ static const char *const gbCliCreateOptLookup[] = {
   [GB_CLI_CREATE_AUTH]     = "auth",
   [GB_CLI_CREATE_PREALLOC] = "prealloc",
   [GB_CLI_CREATE_STORAGE]  = "storage",
+  [GB_CLI_CREATE_TYPE]     = "type",
 
   [GB_CLI_CREATE_OPT_MAX]  = NULL,
+};
+
+typedef enum gbCliCreateTypeOptions {
+  GB_CLI_CREATE_TYPE_GLFS   = 0,
+  GB_CLI_CREATE_TYPE_FUSE   = 1,
+
+  GB_CLI_CREATE_TYPE_OPT_MAX
+} gbCliCreateTypeOptions;
+
+
+static const char *const gbCliCreateTypeOptLookup[] = {
+  [GB_CLI_CREATE_TYPE_GLFS] = "glfs",
+  [GB_CLI_CREATE_TYPE_FUSE] = "fuse",
+
+  [GB_CLI_CREATE_TYPE_OPT_MAX]  = NULL,
 };
 
 typedef enum gbDaemonCmdlineOption {
@@ -446,6 +464,7 @@ typedef enum Metakey {
   GB_META_ENTRYCREATE = 4,
   GB_META_ENTRYDELETE = 5,
   GB_META_PASSWD      = 6,
+  GB_META_TYPE        = 7,
 
   GB_METAKEY_MAX
 } Metakey;
@@ -458,6 +477,7 @@ static const char *const MetakeyLookup[] = {
   [GB_META_ENTRYCREATE] = "ENTRYCREATE",
   [GB_META_ENTRYDELETE] = "ENTRYDELETE",
   [GB_META_PASSWD]      = "PASSWORD",
+  [GB_META_TYPE]        = "TYPE",
 
   [GB_METAKEY_MAX]      = NULL
 };
@@ -530,6 +550,8 @@ static const char *const RemoteCreateRespLookup[] = {
 int glusterBlockCLIOptEnumParse(const char *opt);
 
 int glusterBlockCLICreateOptEnumParse(const char *opt);
+
+int glusterBlockCLICreateTypeOptEnumParse(const char *opt);
 
 int glusterBlockDaemonOptEnumParse(const char *opt);
 


### PR DESCRIPTION
$ gluster-block help
gluster-block (0.3)
usage:
  gluster-block <command> <volname[/blockname]> [<args>] [--json*]

commands:
  create  <volname/blockname> [ha <count>]
                              [type <glfs|fuse>
                              [auth <enable|disable>]
                              [prealloc <full|no>]
                              [storage <filename>]
                              <host1[,host2,...]> <size>
        create block device [defaults: ha 1, type glfs, auth disable, prealloc no, size in bytes]
[...]
supported JSON formats:
  --json|--json-plain|--json-spaced|--json-pretty

$ gluster-block create test/block type fuse 10.215.99.133 1GiB
IQN: iqn.2016-12.org.gluster-block:58d006c4-c89a-4dbb-b765-c956f2011583
PORTAL(S):  10.215.99.133:3260
RESULT: SUCCESS

$ targetcli ls
o- / ................................................................. [...]
  o- backstores ...................................................... [...]
  | o- block .......................................... [Storage Objects: 0]
  | o- fileio ......................................... [Storage Objects: 1]
  | | o- block  [/var/run/gluster-block/test/block-store/58d006c4-c89a-4dbb-
                 b765-c956f2011583 (1.0GiB) write-back activated]
  | |   o- alua ........................................... [ALUA Groups: 1]
  | |     o- default_tg_pt_gp ............... [ALUA state: Active/optimized]
  | o- pscsi .......................................... [Storage Objects: 0]
  | o- ramdisk ........................................ [Storage Objects: 0]
  | o- user:glfs ...................................... [Storage Objects: 0]
  o- iscsi .................................................... [Targets: 1]
  | o- iqn.2016-12.org.gluster-block:58d006c4-c89a-4dbb-b765-c956f2011583  [TPGs: 1]
  |   o- tpg1 .......................................... [gen-acls, no-auth]
  |     o- acls .................................................. [ACLs: 0]
  |     o- luns .................................................. [LUNs: 1]
  |     | o- lun0  [fileio/block (/var/run/gluster-block/test/block-store/58
                    d006c4-c89a-4dbb-b765-c956f2011583) (default_tg_pt_gp)]
  |     o- portals ............................................ [Portals: 1]
  |       o- 10.215.99.133:3260 ....................................... [OK]
  o- loopback ................................................. [Targets: 0]
  o- vhost .................................................... [Targets: 0]

For now prerequisite for testing (TODO):
$ mkdir -p /var/run/gluster-block/${volname}
$ mount.glusterfs localhost:/${volname} /var/run/gluster-block/${volname}

Fixes: #55
Signed-off-by: Prasanna Kumar Kalever <prasanna.kalever@redhat.com>