### PR TITLE
create: add TCMU Ring Buffer size settable

### DIFF
--- a/rpc/glfs-operations.c
+++ b/rpc/glfs-operations.c
@@ -461,6 +461,9 @@ blockStuffMetaInfo(MetaInfo *info, char *line)
   case GB_META_SIZE:
     sscanf(strchr(line, ' '), "%zu", &info->size);
     break;
+  case GB_META_RINGBUFFER:
+    sscanf(strchr(line, ' '), "%zu", &info->rb_size);
+    break;
   case GB_META_HA:
     sscanf(strchr(line, ' '), "%zu", &info->mpath);
     break;

--- a/rpc/glfs-operations.h
+++ b/rpc/glfs-operations.h
@@ -32,6 +32,7 @@ typedef struct MetaInfo {
   char   volume[255];
   char   gbid[38];
   size_t size;
+  size_t rb_size;
   size_t mpath;
   char   entry[16];  /* possible strings for ENTRYCREATE: INPROGRESS|SUCCESS|FAIL */
   char   passwd[38];

--- a/rpc/rpcl/block.x
+++ b/rpc/rpcl/block.x
@@ -25,6 +25,19 @@ struct blockCreate {
   bool      auth_mode;
 };
 
+struct blockCreate2 {
+  char      ipaddr[255];
+  char      volume[255];
+  char      gbid[127];                   /* uuid */
+  char      passwd[127];                 /* uuid */
+  u_quad_t  size;
+  char      block_name[255];
+  string    block_hosts<>;               /* for multiple tpg's creation */
+  bool      auth_mode;
+  u_int     rb_size;                     /* TCMU Ring Buffer size in kernel */
+  opaque    xdata<>;                     /* future reserve */
+};
+
 struct blockModify {
   char      volume[255];
   char      block_name[255];
@@ -51,6 +64,7 @@ struct blockReplace {
 struct blockCreateCli {
   char      volume[255];
   u_quad_t  size;
+  u_int     rb_size;              /* TCMU Ring Buffer size in kernel */
   u_int     mpath;                /* HA request count */
   bool      auth_mode;
   bool      prealloc;
@@ -124,6 +138,8 @@ program GLUSTER_BLOCK {
     blockResponse BLOCK_VERSION() = 4;
     blockResponse BLOCK_REPLACE(blockReplace) = 5;
     blockResponse BLOCK_MODIFY_SIZE(blockModifySize) = 6;
+
+    blockResponse BLOCK_CREATE_V2(blockCreate2) = 7;
   } = 1;
 } = 21215311; /* B2 L12 O15 C3 K11 */
 

--- a/utils/capabilities.h
+++ b/utils/capabilities.h
@@ -40,6 +40,8 @@ enum gbCapabilities {
 
   GB_REPLACE_CAP,
 
+  GB_CREATE_RING_BUFFER_CAP,
+
   GB_JSON_CAP,
 
   GB_CAP_MAX
@@ -51,6 +53,7 @@ static const char *const gbCapabilitiesLookup[] = {
   [GB_CREATE_HA_CAP]           = "create_ha",
   [GB_CREATE_PREALLOC_CAP]     = "create_prealloc",
   [GB_CREATE_AUTH_CAP]         = "create_auth",
+  [GB_CREATE_RING_BUFFER_CAP]  = "create_ring_buffer",
 
   [GB_DELETE_CAP]              = "delete",
   [GB_DELETE_FORCE_CAP]        = "delete_force",

--- a/utils/common.c
+++ b/utils/common.c
@@ -159,6 +159,26 @@ convertStringToTrillianParse(const char *opt)
 }
 
 
+bool
+isNumber(char number[])
+{
+  int i = 0;
+
+
+  // handle negative numbers
+  if (number[0] == '-')
+    i = 1;
+
+  for (; number[i] != 0; i++)
+  {
+    if (!isdigit(number[i]))
+      return false;
+  }
+
+  return true;
+}
+
+
 void
 blockServerDefFree(blockServerDefPtr blkServers)
 {

--- a/utils/common.h
+++ b/utils/common.h
@@ -89,6 +89,8 @@ char* glusterBlockFormatSize(const char *dom, size_t bytes);
 
 int convertStringToTrillianParse(const char *opt);
 
+bool isNumber(char number[]);
+
 void blockServerDefFree(blockServerDefPtr blkServers);
 
 bool blockhostIsValid(char *status);

--- a/utils/gluster-block-caps.info
+++ b/utils/gluster-block-caps.info
@@ -118,3 +118,14 @@ replace: true
 # Since: 0.4
 ##
 modify_size: true
+
+##
+# Nature: cli sub-command
+#
+# Label: 'ring-buffer'
+#
+# Description: capability to create block with given ring buffer size
+#
+# Since: 0.4
+##
+create_ring_buffer: true

--- a/utils/utils.h
+++ b/utils/utils.h
@@ -382,6 +382,7 @@ typedef enum gbCliCreateOptions {
   GB_CLI_CREATE_AUTH      = 2,
   GB_CLI_CREATE_PREALLOC  = 3,
   GB_CLI_CREATE_STORAGE   = 4,
+  GB_CLI_CREATE_RBSIZE    = 5,
 
   GB_CLI_CREATE_OPT_MAX
 } gbCliCreateOptions;
@@ -392,6 +393,7 @@ static const char *const gbCliCreateOptLookup[] = {
   [GB_CLI_CREATE_AUTH]     = "auth",
   [GB_CLI_CREATE_PREALLOC] = "prealloc",
   [GB_CLI_CREATE_STORAGE]  = "storage",
+  [GB_CLI_CREATE_RBSIZE]   = "ring-buffer",
 
   [GB_CLI_CREATE_OPT_MAX]  = NULL,
 };
@@ -448,6 +450,7 @@ typedef enum Metakey {
   GB_META_ENTRYCREATE = 4,
   GB_META_ENTRYDELETE = 5,
   GB_META_PASSWD      = 6,
+  GB_META_RINGBUFFER  = 7,
 
   GB_METAKEY_MAX
 } Metakey;
@@ -460,6 +463,7 @@ static const char *const MetakeyLookup[] = {
   [GB_META_ENTRYCREATE] = "ENTRYCREATE",
   [GB_META_ENTRYDELETE] = "ENTRYDELETE",
   [GB_META_PASSWD]      = "PASSWORD",
+  [GB_META_RINGBUFFER]  = "RINGBUFFER",
 
   [GB_METAKEY_MAX]      = NULL
 };


### PR DESCRIPTION
$ gluster-block --help
[...]
commands:
  create  <volname/blockname> [ha <count>]
                              [auth <enable|disable>]
                              [prealloc <full|no>]
                              [storage <filename>]
                              [ring-buffer <size-in-MB-units>]
                              <host1[,host2,...]> <size>
        create block device [defaults: ha 1, auth disable, prealloc no, size in bytes,
                             ring-buffer default size dependends on kernel]
[...]

$ gluster-block create dht0/block33 ring-buffer 60 ha 3 192.168.195.137,192.168.195.134,192.168.195.135 1G --json-pretty
{
  "IQN":"iqn.2016-12.org.gluster-block:1e9d26a4-28d7-43a5-a2dc-b7d08a6cbedd",
  "PORTAL(S)":[
    "192.168.195.137:3260",
    "192.168.195.134:3260",
    "192.168.195.135:3260"
  ],
  "RESULT":"SUCCESS"
}

$ cat block-meta/block32
VOLUME: dht0
GBID: da787d30-ac8a-420c-8907-09b494e07ebf
HA: 3
ENTRYCREATE: INPROGRESS
SIZE: 1073741824
RINGBUFFER: 60
ENTRYCREATE: SUCCESS
192.168.195.137: CONFIGINPROGRESS
192.168.195.134: CONFIGINPROGRESS
192.168.195.135: CONFIGINPROGRESS
192.168.195.134: CONFIGSUCCESS
192.168.195.137: CONFIGSUCCESS
192.168.195.135: CONFIGSUCCESS

$ targetcli /backstores/user:glfs/block32/ get attribute max_data_area_mb
max_data_area_mb=60 [ro]

Signed-off-by: Xiubo Li <xiubli@redhat.com>
Signed-off-by: Prasanna Kumar Kalever <prasanna.kalever@redhat.com>