### PR TITLE
saveconfig: only alter given block configuration

### DIFF
--- a/daemon/gluster-blockd.c
+++ b/daemon/gluster-blockd.c
@@ -25,7 +25,7 @@
 # define   GB_TGCLI_GLOBALS     "targetcli set "                               \
                                 "global auto_add_default_portal=false "        \
                                 "auto_enable_tpgt=false loglevel_file=info "   \
-                                "logfile=%s && targetcli / saveconfig"
+                                "logfile=%s"
 
 
 extern size_t glfsLruCount;


### PR DESCRIPTION
We use saveconfig in all the remote calls i.e. create/delete/modify/replace.

Currently, if we try to operate on a given block, the consequent saveconfig
will result in rewriting the whole node configuration again as per the current
state of targets in the machine, this could result in override of currently
existing but inactive blocks configuration.

This patch support saving configuration per block. i.e. only the configuration
of the block that is requested is altered, rest all will be untouched.

Thus, this patch can avoid overriding of the currently unloaded configurations.

Signed-off-by: Prasanna Kumar Kalever <prasanna.kalever@redhat.com>