### PR TITLE
rpc: glfs-operations: update api call for ftruncate

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -80,8 +80,10 @@ AC_CHECK_HEADERS([stdio.h stdlib.h string.h stdbool.h stddef.h \
 
 # Checks for libraries.
 # glusterfs-api versions have a prefix of "7."
-PKG_CHECK_MODULES([GFAPI], [glusterfs-api >= 7.3.6],,
-                  [AC_MSG_ERROR([gfapi library >= 3.6 is required to build gluster-block])])
+
+PKG_CHECK_MODULES([GFAPI], [glusterfs-api >= 7.3.6],
+                  [PKG_CHECK_MODULES([gfapi], [glusterfs-api < 7.4.1],[AC_DEFINE([USE_LEGACY_FTRUNCATE],1,[Define 1 if glusterfs-api version < 7.4.1])],true)],
+                 [AC_MSG_ERROR([gfapi library >= 3.6 is required to build gluster-block])])
 AC_SUBST(GFAPI_CFLAGS)
 AC_SUBST(GFAPI_LIBS)
 

--- a/rpc/glfs-operations.c
+++ b/rpc/glfs-operations.c
@@ -8,7 +8,7 @@
   cases as published by the Free Software Foundation.
 */
 
-
+# include <../config.h>
 # include "common.h"
 # include "glfs-operations.h"
 
@@ -174,7 +174,12 @@ glusterBlockCreateEntry(struct glfs *glfs, blockCreateCli *blk, char *gbid,
     ret = -1;
     goto out;
   } else {
-    ret = glfs_ftruncate(tgfd, blk->size, NULL, NULL);
+    #if USE_LEGACY_FTRUNCATE
+     ret = glfs_ftruncate(tgfd, blk->size);
+    #else
+     ret = glfs_ftruncate(tgfd, blk->size, NULL, NULL);
+    #endif
+
     if (ret) {
       *errCode = errno;
       LOG("gfapi", GB_LOG_ERROR,
@@ -269,8 +274,11 @@ glusterBlockResizeEntry(struct glfs *glfs, blockModifySize *blk,
       ret = 0;
       goto close;
     }
-
-    ret = glfs_ftruncate(tgfd, blk->size, NULL, NULL);
+    #if USE_LEGACY_FTRUNCATE
+      ret = glfs_ftruncate(tgfd, blk->size);
+    #else
+       ret = glfs_ftruncate(tgfd, blk->size, NULL, NULL);
+    #endif
     if (ret) {
       *errCode = errno;
       LOG("gfapi", GB_LOG_ERROR,

--- a/rpc/glfs-operations.c
+++ b/rpc/glfs-operations.c
@@ -174,7 +174,7 @@ glusterBlockCreateEntry(struct glfs *glfs, blockCreateCli *blk, char *gbid,
     ret = -1;
     goto out;
   } else {
-    ret = glfs_ftruncate(tgfd, blk->size);
+    ret = glfs_ftruncate(tgfd, blk->size, NULL, NULL);
     if (ret) {
       *errCode = errno;
       LOG("gfapi", GB_LOG_ERROR,
@@ -270,7 +270,7 @@ glusterBlockResizeEntry(struct glfs *glfs, blockModifySize *blk,
       goto close;
     }
 
-    ret = glfs_ftruncate(tgfd, blk->size);
+    ret = glfs_ftruncate(tgfd, blk->size, NULL, NULL);
     if (ret) {
       *errCode = errno;
       LOG("gfapi", GB_LOG_ERROR,


### PR DESCRIPTION
The updated gfapi for glusterfs fop ftruncate has pre/post attributes in the function signature. But this api call inside gluster-block is not updated, so update the api call for ftruncate to resolve build errors.

Signed-off-by: Bhumika Goyal <bgoyal@redhat.com>