### PR TITLE
config-backup: increase max backup files count

### DIFF
--- a/daemon/gluster-blockd.c
+++ b/daemon/gluster-blockd.c
@@ -31,7 +31,8 @@
 # define   GB_TGCLI_GLOBALS     "targetcli set "                               \
                                 "global auto_add_default_portal=false "        \
                                 "auto_enable_tpgt=false loglevel_file=info "   \
-                                "logfile=%s auto_save_on_exit=false"
+                                "logfile=%s auto_save_on_exit=false "          \
+                                "max_backup_files=100"
 
 # define   VERNUM_BUFLEN        8
 


### PR DESCRIPTION
$ targetcli get global max_backup_files
max_backup_files=10000

Signed-off-by: Prasanna Kumar Kalever <prasanna.kalever@redhat.com>