### PR TITLE
AuditLog Feature

### DIFF
--- a/cli/gluster-block.c
+++ b/cli/gluster-block.c
@@ -316,6 +316,20 @@ glusterBlockParseVolumeBlock(char *volumeblock, char *volume, char *block,
   return ret;
 }
 
+void getCommandString(char **cmd, int argcount, char **options)
+{
+   int total_length = 0;
+   int i;
+   for(i = 1; i< argcount; i++){
+	total_length = total_length + strlen(options[i])+1;
+   }
+   *cmd = (char *)malloc((total_length+1)*sizeof(char));
+   for(i=1; i< argcount; i++){
+	strcat(*cmd, options[i]);
+	strcat(*cmd, " ");
+   }
+}
+
 static int
 glusterBlockModify(int argcount, char **options, int json)
 {
@@ -363,7 +377,7 @@ glusterBlockModify(int argcount, char **options, int json)
     GB_STRCPYSTATIC(mobj.volume, volume);
     GB_STRCPYSTATIC(mobj.block_name, block);
     mobj.json_resp = json;
-
+    getCommandString(&mobj.cmd, argcount, options);
     ret = glusterBlockCliRPC_1(&mobj, MODIFY_CLI);
     if (ret) {
       LOG("cli", GB_LOG_ERROR,
@@ -401,6 +415,7 @@ glusterBlockModify(int argcount, char **options, int json)
     GB_STRCPYSTATIC(msobj.block_name, block);
     msobj.size = sparse_ret;  /* size is unsigned long long */
     msobj.json_resp = json;
+    getCommandString(&msobj.cmd, argcount, options);
 
     ret = glusterBlockCliRPC_1(&msobj, MODIFY_SIZE_CLI);
     if (ret) {
@@ -561,6 +576,7 @@ glusterBlockCreate(int argcount, char **options, int json)
     cobj.size = sparse_ret;  /* size is unsigned long long */
   }
 
+  getCommandString(&cobj.cmd, argcount, options);
   ret = glusterBlockCliRPC_1(&cobj, CREATE_CLI);
   if (ret) {
     LOG("cli", GB_LOG_ERROR,
@@ -648,6 +664,8 @@ glusterBlockDelete(int argcount, char **options, int json)
         " for <%s/%s>", options[optind], dobj.volume, dobj.block_name);
     goto out;
   }
+
+  getCommandString(&dobj.cmd, argcount, options);
 
   ret = glusterBlockCliRPC_1(&dobj, DELETE_CLI);
   if (ret) {

--- a/rpc/rpcl/block.x
+++ b/rpc/rpcl/block.x
@@ -71,6 +71,7 @@ struct blockCreateCli {
   char      storage[255];
   char      block_name[255];
   string    block_hosts<>;
+  string    cmd<>;
   enum JsonResponseFormat     json_resp;
 };
 
@@ -79,6 +80,7 @@ struct blockDeleteCli {
   char      volume[255];
   bool      unlink;
   bool      force;
+  string    cmd<>;
   enum JsonResponseFormat     json_resp;
 };
 
@@ -103,6 +105,7 @@ struct blockModifyCli {
   char      block_name[255];
   char      volume[255];
   bool      auth_mode;
+  string     cmd<>;
   enum JsonResponseFormat     json_resp;
 };
 
@@ -111,6 +114,7 @@ struct blockModifySizeCli {
   char      volume[255];
   u_quad_t  size;
   bool      force;
+  string    cmd<>;
   enum JsonResponseFormat     json_resp;
 };
 

--- a/utils/utils.c
+++ b/utils/utils.c
@@ -16,7 +16,7 @@
 # include "config.h"
 
 
-struct gbConf gbConf = {GB_LOG_INFO, GB_LOGDIR, '\0', '\0', '\0', '\0'};
+struct gbConf gbConf = {GB_LOG_INFO, GB_LOGDIR, '\0', '\0', '\0', '\0', '\0'};
 
 const char *argp_program_version = ""                                 \
   PACKAGE_NAME" ("PACKAGE_VERSION")"                                  \
@@ -244,6 +244,8 @@ initLogging(void)
            "%s/gluster-block-gfapi.log", logDir);
   snprintf(gbConf.configShellLogFile, PATH_MAX,
            "%s/gluster-block-configshell.log", logDir);
+  snprintf(gbConf.cmdhistoryLogFile, PATH_MAX,
+          "%s/cmd_history.log", logDir);
 
   if(!glusterBlockLogdirCreate()) {
     return EXIT_FAILURE;

--- a/utils/utils.h
+++ b/utils/utils.h
@@ -127,6 +127,7 @@ struct gbConf {
   char cliLogFile[PATH_MAX];
   char gfapiLogFile[PATH_MAX];
   char configShellLogFile[PATH_MAX];
+  char cmdhistoryLogFile[PATH_MAX];
 };
 
 extern struct gbConf gbConf;


### PR DESCRIPTION
Record the responses of all the requests for the operations Create/Delete/Modify
on gluster-block. The logging format is:
In case of success:
[time] <command string>: SUCCESS: Response string

In case of failure:
[time] <command string>: FAILURE: Response string

Logging is done at the CLI thread of gluster-blockd.
Records are logged into cmd_history.log file.

CLI:
`create block-test-replica-1/sample-block-38 ha 2 192.168.100.210,192.168.100.200 1GiB --json`

cmd_history.log file
`[2018-05-06 22:39:51.948854] create block-test-replica-1/sample-block-38 ha 2 192.168.100.210,192.168.100.200 1GiB : SUCCESS: { "IQN": "iqn.2016-12.org.gluster-block:87ed75d7-0410-4def-94fe-070f6153ade1", "PORTAL(S)": [ "192.168.100.210:3260", "192.168.100.200:3260" ], "RESULT": "SUCCESS" }`

CLI:
` gluster-block modify block-test-replica-1/sample-block-39 auth enable`

cmd_history.log
`[2018-05-06 22:43:33.877227] modify block-test-replica-1/sample-block-39 auth enable : SUCCESS: IQN: iqn.2016-12.org.gluster-block:59dcfbea-31ab-4d16-92bf-0c9bf89ea954 USERNAME: 59dcfbea-31ab-4d16-92bf-0c9bf89ea954 PASSWORD: a98fb809-c86a-43ad-93e5-7b71cf2c5168 SUCCESSFUL ON:  192.168.100.210 192.168.100.200 RESULT: SUCCESS`

CLI:
`gluster-block modify block-test-replica-1/sample-block-39 size 2GiB
`
cmd_history.log
`[2018-05-06 22:46:30.538007] modify block-test-replica-1/sample-block-39 size 2GiB : SUCCESS: IQN: iqn.2016-12.org.gluster-block:59dcfbea-31ab-4d16-92bf-0c9bf89ea954 SIZE: 2.0 GiB SUCCESSFUL ON:  192.168.100.210 192.168.100.200 RESULT: SUCCESS `

CLI
`gluster-block delete block-test-replica-1/sample-block-98` 

log
`[2018-05-06 23:01:52.676364] delete block-test-replica-1/sample-block-98 : FAIL: block block-test-replica-1/sample-block-98 doesn't exist RESULT:FAIL `

Signed-off-by: Bhumika Goyal <bgoyal@redhat.com>