### PR TITLE
gluster-block: set the cmd_time_out to 130

### DIFF
--- a/rpc/block_svc_routines.c
+++ b/rpc/block_svc_routines.c
@@ -4243,7 +4243,7 @@ block_create_common(blockCreate *blk, char *rbsize, char *prio_path)
   }
 
   if (GB_ASPRINTF(&backstore_attr,
-                  "%s/%s set attribute cmd_time_out=0",
+                  "%s/%s set attribute cmd_time_out=130",
                   GB_TGCLI_GLFS_PATH, blk->block_name) == -1) {
     goto out;
   }


### PR DESCRIPTION
0 means the fired or pending SCSI commands will wait forever, and
when the IOs going on and tcmu-runner process is crashed, so the
iscsi_ttx process will stucked forever.

Fixes: bz#1596684

Signed-off-by: Xiubo Li <xiubli@redhat.com>