### PR TITLE
gluster-block: set the cmd_time_out to 130 for genconf

### DIFF
--- a/rpc/block_svc_routines.c
+++ b/rpc/block_svc_routines.c
@@ -46,6 +46,8 @@
 # define   GB_ALUA_ANO_TPG_NAME         "glfs_tg_pt_gp_ano"
 # define   GB_RING_BUFFER_STR           "max_data_area_mb"
 
+#define    GB_CMD_TIME_OUT      130
+
 # define   GB_OLD_CAP_MAX       9
 
 # define   GB_OP_SKIPPED        222
@@ -2701,7 +2703,7 @@ getSoObj(char *block, MetaInfo *info, blockGenConfigCli *blk)
   // ]
 
   // "attributes": {
-  json_object_object_add(so_obj_attr, "cmd_time_out", json_object_new_int(0));
+  json_object_object_add(so_obj_attr, "cmd_time_out", json_object_new_int(GB_CMD_TIME_OUT));
   json_object_object_add(so_obj_attr, "dev_size", json_object_new_int64(info->size));
 
   json_object_object_add(so_obj, "attributes", so_obj_attr);
@@ -4243,8 +4245,8 @@ block_create_common(blockCreate *blk, char *rbsize, char *prio_path)
   }
 
   if (GB_ASPRINTF(&backstore_attr,
-                  "%s/%s set attribute cmd_time_out=130",
-                  GB_TGCLI_GLFS_PATH, blk->block_name) == -1) {
+                  "%s/%s set attribute cmd_time_out=%d",
+                  GB_TGCLI_GLFS_PATH, blk->block_name, GB_CMD_TIME_OUT) == -1) {
     goto out;
   }
 


### PR DESCRIPTION
For the last commit just forget the genconf.

Setting cmd_time_out to 0 means that the iscsi_trx will wait
infinite until the cmds fired to tcmu-runner return back. Just
in case if tcmu-runner is killed/terminated, the iscsi_trx will
hung in D state infinitely, which later result in KERNEL WARNING
messages, like:

(2018-07-02 2:44:41 PM) xiubli_2: Jul 02 04:38:34 rhel1 kernel: Call Trace:
(2018-07-02 2:44:43 PM) xiubli_2: Jul 02 04:38:34 rhel1 kernel: iscsi_ttx D ffff9a69b6a64100 0 3413 2 0x00000084
[...]

The defaults,
GLUSTER ping timeout = 42
/etc/iscsi/iscsi.conf:node.session.timeo.replacement_timeout = 120

so cmd_time_out should be
cmd_time_out > GLUSTER ping timeout && cmd_time_out > replacement_timeout

The hack is to make cmd_time_out expire after
fast_io_fail_tmo/replacement_timeout. This way the path will be
marked bad by multipathd and the IO failed due to cmd_time_out
firing will be retried on another path instead of the one where
runner is down. Path tester IO will still get sent to the down
path but that will not disrupt IO on good paths.

Though the D state could recovery from LIO's reset ring option,
this is still needed.

We must make sure that the customer's setting of replacement_timeout
value < 130 and tell customer that when this bz is hit, there will
be 130 seconds' stuck of gluster-block/tcmu-runner node.

Fixes: bz#1596684

Signed-off-by: Xiubo Li <xiubli@redhat.com>