### PR TITLE
Script to wait for bricks to come online

### DIFF
--- a/extras/wait-for-bricks.sh
+++ b/extras/wait-for-bricks.sh
@@ -1,0 +1,162 @@
+#!/bin/bash
+#Copyright (c) 2018 Red Hat, Inc. <http://www.redhat.com>
+#This file is part of gluster-block.
+#
+#This file is licensed to you under your choice of the GNU Lesser
+#General Public License, version 3 or any later version (LGPLv3 or
+#later), or the GNU General Public License, version 2 (GPLv2), in all
+#cases as published by the Free Software Foundation.
+
+# This file waits for gluster block hosting volume bricks to be up. If all the
+# bricks are up, it exits with success status, otherwise waits for the $timeout
+# seconds before erroring out with the status about
+# online-bricks/expected-online-bricks
+
+LOGDIR="${GB_LOGDIR:-/var/log/gluster-block}"
+mkdir -p "${LOGDIR}"
+
+function printLog()
+{
+    local msg=${1}
+
+    echo "[$(date -u +'%Y-%m-%d %I:%M:%S')] ${msg}" >> "${LOGDIR}/gluster-block-bricks-start.log"
+}
+
+function volinfo_field()
+{
+    local vol=$1;
+    local field=$2;
+
+    gluster volume info "$vol" --xml | grep -oPm1 "(?<=<$field>)[^<]+"
+}
+
+function is_enabled()
+{
+        case "$1" in
+        0|off|no|false|disable)
+                echo "N"
+                ;;
+        1|on|yes|true|enable)
+                echo "Y"
+                ;;
+        *)
+                echo "N/A"
+                ;;
+        esac
+}
+
+function volinfo_option()
+{
+    local vol=$1;
+    local key=$2;
+
+    gluster volume get "$vol" "$key"| awk '{print $NF}' | tail -1
+}
+
+function check_brick_status() {
+        local volname=$1
+        local daemon=$2
+
+        cmd="gluster --xml volume status $volname"
+        if [[ -z "$daemon" ]]
+        then
+                 $cmd | grep -c '<status>1'
+        else
+                 $cmd | sed -n -e "/${daemon}/,/<status>/ p" | grep -c '<status>1'
+        fi
+}
+
+function volume_online_brick_count()
+{
+        local volname=$1
+        local v1=0
+        local v2=0
+        local v3=0
+        local v4=0
+        local v5=0
+        local tot=0
+
+        #First count total Number of bricks and then subtract daemon status
+        v1=$(check_brick_status "$volname")
+        v2=$(check_brick_status "$volname" "Self-heal")
+        v3=$(check_brick_status "$volname" "Quota")
+        v4=$(check_brick_status "$volname" "Snapshot")
+        v5=$(check_brick_status "$volname" "Tier")
+        tot=$((v1-v2-v3-v4-v5))
+        echo $tot
+}
+
+function volumes_waiting_for_bricks_up()
+{
+        local wait_info
+        local vol_down_info
+        while read -r volname
+        do
+                if [[ "Started" == "$(volinfo_field "$volname" 'statusStr')" ]]
+                then
+                        if [[ "Y" == "$(is_enabled "$(volinfo_option "$volname" features.shard)")" ]]
+                        then
+                                brick_count="$(volume_online_brick_count "$volname")"
+                                total_brick_count=$(volinfo_field "$volname" 'brickCount')
+                                if [[ $brick_count -ne $total_brick_count ]]
+                                then
+                                        vol_down_info="$volname ($((total_brick_count - brick_count))/$total_brick_count)"
+                                        if [[ -z "$wait_info" ]]
+                                        then
+                                                wait_info="$vol_down_info"
+                                        else
+                                                wait_info="$wait_info, $vol_down_info"
+                                        fi
+                                fi
+                        fi
+                fi
+        done < <(gluster volume list)
+        if [[ ! -z "$wait_info" ]]; then echo "$wait_info"; fi
+}
+
+function check_glusterd_running()
+{
+        if ! pidof glusterd > /dev/null 2>&1
+        then
+                printLog "ERROR: Glusterd is not running";
+                exit 1;
+        fi
+}
+
+function wait_for_bricks_up()
+{
+        local endtime=$1
+        local now
+
+        while [[ ! -z "$(volumes_waiting_for_bricks_up)" ]]
+        do
+                now=$(date +%s%N)
+                if [[ $now -ge $endtime ]]
+                then
+                        printLog "WARNING: Timeout Expired, bricks of volumes:\"$(volumes_waiting_for_bricks_up)\" are yet to come online"
+                        exit 1
+                fi
+                sleep 1;
+        done
+}
+
+if [[ "$#" -ne 1 ]]
+then
+        echo "Usage $0 <timeout-in-seconds>"
+        exit 1
+fi
+
+case $1 in
+    ''|*[!0-9]*) echo "Usage $0 <timeout-in-seconds>"; exit 1 ;;
+    *) ;;
+esac
+
+check_glusterd_running;
+timeout=$1
+start=$(date +%s%N)
+#Convert timeout to Nano Seconds as 'start' is in Nano seconds
+endtime=$(( timeout*1000000000 + start ))
+wait_for_bricks_up $endtime
+now=$(date +%s%N)
+printLog "INFO: All bricks for Block Hosting Volumes came online in $(((now-start)/1000000000)) seconds"
+exit 0

--- a/tests/glusterfs/wait-for-bricks-test.sh
+++ b/tests/glusterfs/wait-for-bricks-test.sh
@@ -1,0 +1,99 @@
+#!/bin/bash -x
+
+#This test-script tests that wait-for-bricks.sh works as expected in different cases
+exit_code=0
+source_path="../../extras"
+
+function test_success {
+        if ! "$@" ;
+        then
+                exit_code=1
+        fi
+}
+
+function test_failure {
+        if "$@" ;
+        then
+                exit_code=1
+        fi
+}
+
+#Should fail when glusterd is not running
+test_failure $source_path/wait-for-bricks.sh 10
+
+#Should succeed when gluster --mode=scriptd is running but no volumes exist
+glusterd
+test_success $source_path/wait-for-bricks.sh 10
+
+#Set brick-multiplexing off, so that we can kill bricks.
+gluster volume set all cluster.brick-multiplex off
+
+#Block hosting volumes are identified with features.shard being present for now
+#Should succeed when volumes that are not of interest are present
+gluster --mode=script volume create vol localhost.localdomain:/brick1 force
+test_success $source_path/wait-for-bricks.sh 10
+
+gluster --mode=script volume start vol
+test_success $source_path/wait-for-bricks.sh 10
+
+gluster --mode=script volume create vol2 replica 3 localhost.localdomain:/brick{2..4} force
+test_success $source_path/wait-for-bricks.sh 10
+
+gluster --mode=script volume start vol2
+test_success $source_path/wait-for-bricks.sh 10
+
+#Checking for the case when only the volume with replicate is available
+gluster --mode=script volume stop vol
+test_success $source_path/wait-for-bricks.sh 10
+gluster --mode=script volume start vol
+
+#Checking for the case where bhv is present but stopped
+gluster --mode=script volume create bhv1 replica 3 localhost.localdomain:/brick{5..7} force
+gluster --mode=script volume set bhv1 features.shard on
+test_success $source_path/wait-for-bricks.sh 10
+
+#Start bhv1 so that wait-for-bricks considers this volume
+gluster --mode=script volume start bhv1
+test_success $source_path/wait-for-bricks.sh 10
+
+#When a brick in bhv1 is down, script should fail
+kill -9 "$(gluster --mode=script --xml volume status bhv1 | grep -oPm1 "(?<=<pid>)[^<]+")"
+test_failure $source_path/wait-for-bricks.sh 10
+
+gluster --mode=script volume start bhv1 force
+#Kill a brick from non block hosting volume and the script should succeed
+kill -9 "$(gluster --mode=script --xml volume status vol2 | grep -oPm1 "(?<=<pid>)[^<]+")"
+test_success $source_path/wait-for-bricks.sh 10
+
+#Create one more block hosting volume to test that brick down in any one bhv leads to failure
+gluster --mode=script volume create bhv2 replica 3 localhost.localdomain:/brick{8..10} force
+gluster --mode=script volume set bhv2 features.shard on
+test_success $source_path/wait-for-bricks.sh 10
+
+gluster --mode=script volume start bhv2
+test_success $source_path/wait-for-bricks.sh 10
+
+kill -9 "$(gluster --mode=script --xml volume status bhv2 | grep -oPm1 "(?<=<pid>)[^<]+")"
+test_failure $source_path/wait-for-bricks.sh 10
+
+#Brick in each Block hosting volume is down
+kill -9 "$(gluster --mode=script --xml volume status bhv1 | grep -oPm1 "(?<=<pid>)[^<]+")"
+test_failure $source_path/wait-for-bricks.sh 10
+
+#1 Brick is down in 1 Block hosting volume and on the other all bricks are up
+gluster --mode=script v start bhv2 force
+test_failure $source_path/wait-for-bricks.sh 10
+
+gluster --mode=script volume start bhv1 force
+test_success $source_path/wait-for-bricks.sh 10
+
+gluster --mode=script v stop bhv1
+gluster --mode=script v stop bhv2
+gluster --mode=script v stop vol
+gluster --mode=script v stop vol2
+gluster --mode=script v delete bhv1
+gluster --mode=script v delete bhv2
+gluster --mode=script v delete vol
+gluster --mode=script v delete vol2
+killall -9 glusterd
+exit $exit_code


### PR DESCRIPTION
Problem:
When a node is rebooted, by the time tcmu-runner starts there is no
guarantee that the bricks of the volume on which the block-volumes
are created will be online. This leads to a case where doing open
on the block files leads to open failing with ENOTCONN leading
to containers with this as pvc are in failed state.

Fix:
A script is added which will be added as a unit file dependency for
gluster-blockd which makes sure that the bricks are online for the
block-hosting-volume preventing this situation.