### PR TITLE
gluster-block: install wait-for-bricks.sh

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -1,6 +1,6 @@
 ACLOCAL_AMFLAGS = -I m4
 
-SUBDIRS = rpc utils cli daemon systemd docs
+SUBDIRS = rpc utils cli daemon systemd docs extras
 
 DISTCLEANFILES = Makefile.in gluster-block.spec autom4te.cache
 

--- a/configure.ac
+++ b/configure.ac
@@ -51,7 +51,8 @@ AC_CONFIG_FILES([gluster-block.spec
                  systemd/gluster-blockd.service
                  systemd/gluster-block-target.service
                  systemd/gluster-blockd.initd
-                 docs/Makefile])
+                 docs/Makefile
+                 extras/Makefile])
 AC_CONFIG_MACRO_DIR([m4])
 m4_ifdef([AM_PROG_AR], [AM_PROG_AR])
 
@@ -102,6 +103,20 @@ if test "x$prefix" = xNONE; then
    test $localstatedir = '${prefix}/var' && localstatedir=$ac_default_prefix/var
    localstatedir=/var
 fi
+
+localstatedir="$(eval echo ${localstatedir})"
+LOCALSTATEDIR=${localstatedir}
+
+GLUSTER_BLOCKD_WORKDIR="${LOCALSTATEDIR}/lib/gluster-block"
+AC_SUBST(GLUSTER_BLOCKD_WORKDIR)
+
+if test "x$prefix" = xNONE; then
+   test $libexecdir = '${prefix}/libexec' && localstatedir=$ac_default_prefix/libexec
+   libexecdir=/usr/libexec
+fi
+
+GLUSTER_BLOCKD_LIBEXECDIR="$(eval echo ${libexecdir}/gluster-block)"
+AC_SUBST(GLUSTER_BLOCKD_LIBEXECDIR)
 
 # Checks for typedefs, structures, and compiler characteristics.
 AC_CHECK_HEADER_STDBOOL

--- a/extras/Makefile.am
+++ b/extras/Makefile.am
@@ -1,0 +1,13 @@
+EXTRA_DIST = replace-node.sh wait-for-bricks.sh
+
+DISTCLEANFILES = Makefile.in
+
+CLEANFILES = *~
+
+install-data-local:
+	$(MKDIR_P) $(DESTDIR)$(GLUSTER_BLOCKD_LIBEXECDIR);                           \
+	$(INSTALL_DATA) -m 755 $(top_srcdir)/extras/wait-for-bricks.sh               \
+		$(DESTDIR)$(GLUSTER_BLOCKD_LIBEXECDIR)/wait-for-bricks.sh
+
+uninstall-local:
+	rm -f $(DESTDIR)$(GLUSTER_BLOCKD_LIBEXECDIR)/wait-for-bricks.sh

--- a/gluster-block.spec.in
+++ b/gluster-block.spec.in
@@ -77,12 +77,19 @@ rm -rf ${RPM_BUILD_ROOT}
 %{_unitdir}/gluster-blockd.service
 %{_unitdir}/gluster-block-target.service
 %else
-%attr(755, root, root) %{_initddir}/gluster-blockd
+%attr(0755,-,-) %{_initddir}/gluster-blockd
 %endif
 %config(noreplace) %{_sysconfdir}/sysconfig/gluster-blockd
-%{_sysconfdir}/sysconfig/gluster-block-caps.info
+%dir %attr(0755,-,-) %{_libexecdir}/gluster-block
+     %attr(0755,-,-) %{_libexecdir}/gluster-block/wait-for-bricks.sh
+%dir %attr(0755,-,-) %{_sharedstatedir}/gluster-block
+     %attr(0644,-,-) %{_sharedstatedir}/gluster-block/gluster-block-caps.info
 
 %changelog
+* Tue Jul 17 2018 Prasanna Kumar Kalever <prasanna.kalever@redhat.com>
+- change install path for gluster-block-caps.info
+- add install details for wait-for-bricks.sh
+
 * Tue Mar 06 2018 Prasanna Kumar Kalever <prasanna.kalever@redhat.com>
 - update about gluster-block-caps.info
 

--- a/systemd/gluster-block-target.service.in
+++ b/systemd/gluster-block-target.service.in
@@ -12,3 +12,6 @@ Conflicts=target.service
 Requisite=glusterd.service
 BindsTo=tcmu-runner.service
 After=glusterd.service tcmu-runner.service
+
+[Service]
+TimeoutStartSec=600

--- a/systemd/gluster-blockd.service.in
+++ b/systemd/gluster-blockd.service.in
@@ -12,6 +12,7 @@ Environment="GB_LOG_LEVEL=INFO"
 EnvironmentFile=-@sysconfigdir@/gluster-blockd
 ExecStart=@prefix@/sbin/gluster-blockd --glfs-lru-count $GB_GLFS_LRU_COUNT --log-level $GB_LOG_LEVEL $GB_EXTRA_ARGS
 KillMode=process
+TimeoutStartSec=600
 
 [Install]
 WantedBy=multi-user.target

--- a/utils/Makefile.am
+++ b/utils/Makefile.am
@@ -4,8 +4,8 @@ libgb_la_SOURCES = common.c utils.c lru.c capabilities.c
 
 noinst_HEADERS = common.h utils.h lru.h list.h capabilities.h
 
-libgb_la_CFLAGS = $(GFAPI_CFLAGS)                                              \
-                  -DDATADIR=\"$(localstatedir)\" -DCONFDIR=\"$(sysconfigdir)\" \
+libgb_la_CFLAGS = $(GFAPI_CFLAGS) -DDATADIR=\"$(localstatedir)\"               \
+                  -DCONFDIR=\"$(GLUSTER_BLOCKD_WORKDIR)\"                      \
                   -I$(top_builddir)/ -I$(top_builddir)/rpc/rpcl
 
 libgb_la_LIBADD = $(GFAPI_LIBS)
@@ -19,9 +19,9 @@ DISTCLEANFILES = Makefile.in
 CLEANFILES = *~
 
 install-data-local:
-	$(MKDIR_P) $(DESTDIR)${sysconfigdir};                    \
-	$(INSTALL_DATA) gluster-block-caps.info                  \
-		$(DESTDIR)${sysconfigdir}/gluster-block-caps.info;
+	$(MKDIR_P) $(DESTDIR)$(GLUSTER_BLOCKD_WORKDIR);                              \
+	$(INSTALL_DATA) gluster-block-caps.info                                      \
+		$(DESTDIR)$(GLUSTER_BLOCKD_WORKDIR)/gluster-block-caps.info;
 
 uninstall-local:
-	rm -f $(DESTDIR)${sysconfigdir}/gluster-block-caps.info
+	rm -f $(DESTDIR)$(GLUSTER_BLOCKD_WORKDIR)/gluster-block-caps.info


### PR DESCRIPTION
This patch:
* install wait-for-bricks.sh (source install and rpm install)
* change install path of gluster-block-caps.info

depends on #98
Signed-off-by: Prasanna Kumar Kalever <prasanna.kalever@redhat.com>