### PR TITLE
wait-for-bricks: Use ps instead of pidof, improve performance

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -1,6 +1,6 @@
 ACLOCAL_AMFLAGS = -I m4
 
-SUBDIRS = rpc utils cli daemon systemd docs
+SUBDIRS = rpc utils cli daemon systemd docs extras
 
 DISTCLEANFILES = Makefile.in gluster-block.spec autom4te.cache
 

--- a/cli/gluster-block.c
+++ b/cli/gluster-block.c
@@ -59,7 +59,7 @@ glusterBlockCliRPC_1(void *cobj, clioperations opt)
 {
   CLIENT *clnt = NULL;
   int ret = -1;
-  int sockfd = -1;
+  int sockfd = RPC_ANYSOCK;
   struct sockaddr_un saun = {0,};
   blockCreateCli *create_obj;
   blockDeleteCli *delete_obj;
@@ -204,7 +204,7 @@ glusterBlockCliRPC_1(void *cobj, clioperations opt)
     clnt_destroy (clnt);
   }
 
-  if (sockfd != -1) {
+  if (sockfd != RPC_ANYSOCK) {
     close (sockfd);
   }
 

--- a/configure.ac
+++ b/configure.ac
@@ -51,7 +51,8 @@ AC_CONFIG_FILES([gluster-block.spec
                  systemd/gluster-blockd.service
                  systemd/gluster-block-target.service
                  systemd/gluster-blockd.initd
-                 docs/Makefile])
+                 docs/Makefile
+                 extras/Makefile])
 AC_CONFIG_MACRO_DIR([m4])
 m4_ifdef([AM_PROG_AR], [AM_PROG_AR])
 
@@ -102,6 +103,20 @@ if test "x$prefix" = xNONE; then
    test $localstatedir = '${prefix}/var' && localstatedir=$ac_default_prefix/var
    localstatedir=/var
 fi
+
+localstatedir="$(eval echo ${localstatedir})"
+LOCALSTATEDIR=${localstatedir}
+
+GLUSTER_BLOCKD_WORKDIR="${LOCALSTATEDIR}/lib/gluster-block"
+AC_SUBST(GLUSTER_BLOCKD_WORKDIR)
+
+if test "x$prefix" = xNONE; then
+   test $libexecdir = '${prefix}/libexec' && localstatedir=$ac_default_prefix/libexec
+   libexecdir=/usr/libexec
+fi
+
+GLUSTER_BLOCKD_LIBEXECDIR="$(eval echo ${libexecdir}/gluster-block)"
+AC_SUBST(GLUSTER_BLOCKD_LIBEXECDIR)
 
 # Checks for typedefs, structures, and compiler characteristics.
 AC_CHECK_HEADER_STDBOOL

--- a/daemon/gluster-blockd.c
+++ b/daemon/gluster-blockd.c
@@ -61,7 +61,7 @@ glusterBlockCliThreadProc (void *vargp)
 {
   register SVCXPRT *transp = NULL;
   struct sockaddr_un saun = {0, };
-  int sockfd = -1;
+  int sockfd = RPC_ANYSOCK;
 
 
   if (strlen(GB_UNIX_ADDRESS) > SUN_PATH_MAX) {
@@ -116,7 +116,7 @@ glusterBlockCliThreadProc (void *vargp)
     svc_destroy(transp);
   }
 
-  if (sockfd != -1) {
+  if (sockfd != RPC_ANYSOCK) {
     close(sockfd);
   }
 
@@ -129,7 +129,7 @@ glusterBlockServerThreadProc(void *vargp)
 {
   register SVCXPRT *transp = NULL;
   struct sockaddr_in sain = {0, };
-  int sockfd;
+  int sockfd = RPC_ANYSOCK;
   int opt = 1;
   char errMsg[2048] = {0};
 
@@ -177,7 +177,7 @@ glusterBlockServerThreadProc(void *vargp)
     svc_destroy(transp);
   }
 
-  if (sockfd != -1) {
+  if (sockfd != RPC_ANYSOCK) {
     close(sockfd);
   }
 

--- a/daemon/gluster-blockd.c
+++ b/daemon/gluster-blockd.c
@@ -21,6 +21,7 @@
 # include  "lru.h"
 # include  "block.h"
 # include  "block_svc.h"
+# include  "capabilities.h"
 
 # define   GB_TGCLI_GLOBALS     "targetcli set "                               \
                                 "global auto_add_default_portal=false "        \
@@ -303,6 +304,21 @@ blockNodeSanityCheck(void)
   return 0;
 }
 
+
+static int
+initDaemonCapabilities(void)
+{
+
+  gbSetCapabilties();
+  if (!globalCapabilities) {
+    LOG("mgmt", GB_LOG_ERROR, "%s", "capabilities fetching failed");
+    return -1;
+  }
+
+  return 0;
+}
+
+
 int
 main (int argc, char **argv)
 {
@@ -343,6 +359,11 @@ main (int argc, char **argv)
   if (errnosv) {
     exit(errnosv);
   }
+
+  if (initDaemonCapabilities()) {
+    exit(EXIT_FAILURE);
+  }
+  LOG("mgmt", GB_LOG_INFO, "%s", "capabilities fetched successfully");
 
   initCache();
 

--- a/extras/Makefile.am
+++ b/extras/Makefile.am
@@ -1,0 +1,13 @@
+EXTRA_DIST = replace-node.sh wait-for-bricks.sh
+
+DISTCLEANFILES = Makefile.in
+
+CLEANFILES = *~
+
+install-data-local:
+	$(MKDIR_P) $(DESTDIR)$(GLUSTER_BLOCKD_LIBEXECDIR);                           \
+	$(INSTALL_DATA) -m 755 $(top_srcdir)/extras/wait-for-bricks.sh               \
+		$(DESTDIR)$(GLUSTER_BLOCKD_LIBEXECDIR)/wait-for-bricks.sh
+
+uninstall-local:
+	rm -f $(DESTDIR)$(GLUSTER_BLOCKD_LIBEXECDIR)/wait-for-bricks.sh

--- a/extras/wait-for-bricks.sh
+++ b/extras/wait-for-bricks.sh
@@ -1,0 +1,162 @@
+#!/bin/bash
+#Copyright (c) 2018 Red Hat, Inc. <http://www.redhat.com>
+#This file is part of gluster-block.
+#
+#This file is licensed to you under your choice of the GNU Lesser
+#General Public License, version 3 or any later version (LGPLv3 or
+#later), or the GNU General Public License, version 2 (GPLv2), in all
+#cases as published by the Free Software Foundation.
+
+# This file waits for gluster block hosting volume bricks to be up. If all the
+# bricks are up, it exits with success status, otherwise waits for the $timeout
+# seconds before erroring out with the status about
+# online-bricks/expected-online-bricks
+
+LOGDIR="${GB_LOGDIR:-/var/log/gluster-block}"
+mkdir -p "${LOGDIR}"
+
+function printLog()
+{
+    local msg=${1}
+
+    echo "[$(date -u +'%Y-%m-%d %I:%M:%S')] ${msg}" >> "${LOGDIR}/gluster-block-bricks-start.log"
+}
+
+function volinfo_field()
+{
+    local vol=$1;
+    local field=$2;
+
+    gluster volume info "$vol" --xml | grep -oPm1 "(?<=<$field>)[^<]+"
+}
+
+function is_enabled()
+{
+        case "$1" in
+        0|off|no|false|disable)
+                echo "N"
+                ;;
+        1|on|yes|true|enable)
+                echo "Y"
+                ;;
+        *)
+                echo "N/A"
+                ;;
+        esac
+}
+
+function volinfo_option()
+{
+    local vol=$1;
+    local key=$2;
+
+    gluster volume get "$vol" "$key"| awk '{print $NF}' | tail -1
+}
+
+function check_brick_status() {
+        local volname=$1
+        local daemon=$2
+
+        cmd="gluster --xml volume status $volname"
+        if [[ -z "$daemon" ]]
+        then
+                 $cmd | grep -c '<status>1'
+        else
+                 $cmd | sed -n -e "/${daemon}/,/<status>/ p" | grep -c '<status>1'
+        fi
+}
+
+function volume_online_brick_count()
+{
+        local volname=$1
+        local v1=0
+        local v2=0
+        local v3=0
+        local v4=0
+        local v5=0
+        local tot=0
+
+        #First count total Number of bricks and then subtract daemon status
+        v1=$(check_brick_status "$volname")
+        v2=$(check_brick_status "$volname" "Self-heal")
+        v3=$(check_brick_status "$volname" "Quota")
+        v4=$(check_brick_status "$volname" "Snapshot")
+        v5=$(check_brick_status "$volname" "Tier")
+        tot=$((v1-v2-v3-v4-v5))
+        echo $tot
+}
+
+function volumes_waiting_for_bricks_up()
+{
+        local wait_info
+        local vol_down_info
+        while read -r volname
+        do
+                if [[ "Started" == "$(volinfo_field "$volname" 'statusStr')" ]]
+                then
+                        if [[ "Y" == "$(is_enabled "$(volinfo_option "$volname" features.shard)")" ]]
+                        then
+                                brick_count="$(volume_online_brick_count "$volname")"
+                                total_brick_count=$(volinfo_field "$volname" 'brickCount')
+                                if [[ $brick_count -ne $total_brick_count ]]
+                                then
+                                        vol_down_info="$volname ($((total_brick_count - brick_count))/$total_brick_count)"
+                                        if [[ -z "$wait_info" ]]
+                                        then
+                                                wait_info="$vol_down_info"
+                                        else
+                                                wait_info="$wait_info, $vol_down_info"
+                                        fi
+                                fi
+                        fi
+                fi
+        done < <(gluster volume list)
+        if [[ ! -z "$wait_info" ]]; then echo "$wait_info"; fi
+}
+
+function check_glusterd_running()
+{
+        if ! pidof glusterd > /dev/null 2>&1
+        then
+                printLog "ERROR: Glusterd is not running";
+                exit 1;
+        fi
+}
+
+function wait_for_bricks_up()
+{
+        local endtime=$1
+        local now
+
+        while [[ ! -z "$(volumes_waiting_for_bricks_up)" ]]
+        do
+                now=$(date +%s%N)
+                if [[ $now -ge $endtime ]]
+                then
+                        printLog "WARNING: Timeout Expired, bricks of volumes:\"$(volumes_waiting_for_bricks_up)\" are yet to come online"
+                        exit 1
+                fi
+                sleep 1;
+        done
+}
+
+if [[ "$#" -ne 1 ]]
+then
+        echo "Usage $0 <timeout-in-seconds>"
+        exit 1
+fi
+
+case $1 in
+    ''|*[!0-9]*) echo "Usage $0 <timeout-in-seconds>"; exit 1 ;;
+    *) ;;
+esac
+
+check_glusterd_running;
+timeout=$1
+start=$(date +%s%N)
+#Convert timeout to Nano Seconds as 'start' is in Nano seconds
+endtime=$(( timeout*1000000000 + start ))
+wait_for_bricks_up $endtime
+now=$(date +%s%N)
+printLog "INFO: All bricks for Block Hosting Volumes came online in $(((now-start)/1000000000)) seconds"
+exit 0

--- a/gluster-block.spec.in
+++ b/gluster-block.spec.in
@@ -77,12 +77,19 @@ rm -rf ${RPM_BUILD_ROOT}
 %{_unitdir}/gluster-blockd.service
 %{_unitdir}/gluster-block-target.service
 %else
-%attr(755, root, root) %{_initddir}/gluster-blockd
+%attr(0755,-,-) %{_initddir}/gluster-blockd
 %endif
 %config(noreplace) %{_sysconfdir}/sysconfig/gluster-blockd
-%{_sysconfdir}/sysconfig/gluster-block-caps.info
+%dir %attr(0755,-,-) %{_libexecdir}/gluster-block
+     %attr(0755,-,-) %{_libexecdir}/gluster-block/wait-for-bricks.sh
+%dir %attr(0755,-,-) %{_sharedstatedir}/gluster-block
+     %attr(0644,-,-) %{_sharedstatedir}/gluster-block/gluster-block-caps.info
 
 %changelog
+* Tue Jul 17 2018 Prasanna Kumar Kalever <prasanna.kalever@redhat.com>
+- change install path for gluster-block-caps.info
+- add install details for wait-for-bricks.sh
+
 * Tue Mar 06 2018 Prasanna Kumar Kalever <prasanna.kalever@redhat.com>
 - update about gluster-block-caps.info
 

--- a/rpc/block_svc_routines.c
+++ b/rpc/block_svc_routines.c
@@ -4793,10 +4793,13 @@ block_delete_1_svc_st(blockDelete *blk, struct svc_req *rqstp)
   return reply;
 }
 
+
 blockResponse *
 block_version_1_svc_st(void *data, struct svc_req *rqstp)
 {
   blockResponse *reply = NULL;
+  gbCapObj *caps;
+  int i;
 
 
   LOG("mgmt", GB_LOG_DEBUG, "%s", "version check request");
@@ -4805,14 +4808,25 @@ block_version_1_svc_st(void *data, struct svc_req *rqstp)
     return NULL;
   }
 
-  reply->exit = gbSetCapabilties(&reply);
+  if (GB_ALLOC_N(caps, GB_CAP_MAX) < 0) {
+    GB_FREE(reply);
+    return NULL;
+  }
 
-  GB_ASPRINTF(&reply->out, "remote version check returns %d", reply->exit);
+  for (i = 0; i < GB_CAP_MAX; i++) {
+    GB_STRCPYSTATIC(caps[i].cap, globalCapabilities[i].cap);
+    caps[i].status = globalCapabilities[i].status;
+  }
 
-  LOG("mgmt", GB_LOG_DEBUG, "command exit code, %d", reply->exit);
+  reply->xdata.xdata_len = GB_CAP_MAX * sizeof(gbCapObj);
+  reply->xdata.xdata_val = (char *) caps;
+  reply->exit = 0;
+
+  GB_ASPRINTF(&reply->out, "version check routine");
 
   return reply;
 }
+
 
 blockResponse *
 block_modify_1_svc_st(blockModify *blk, struct svc_req *rqstp)

--- a/rpc/block_svc_routines.c
+++ b/rpc/block_svc_routines.c
@@ -1265,8 +1265,8 @@ glusterBlockDeleteRemoteAsync(char *blockname,
   if (ret) {
     goto out;
   }
-
   ret = -1;
+
   if (d_attempt) {
     a_tmp = local->d_attempt;
     if (GB_ASPRINTF(&local->d_attempt, "%s %s",
@@ -1305,6 +1305,7 @@ glusterBlockDeleteRemoteAsync(char *blockname,
   if (ret) {
     goto out;
   }
+  ret = -1;
 
   for (i = 0; i < info_new->nhosts; i++) {
     switch (blockMetaStatusEnumParse(info_new->list[i]->status)) {

--- a/rpc/block_svc_routines.c
+++ b/rpc/block_svc_routines.c
@@ -592,7 +592,7 @@ glusterBlockCallRPC_1(char *host, void *cobj,
       *rpc_sent = TRUE;
       if (block_create_v2_1(cblk_v2, &reply, clnt) != RPC_SUCCESS) {
         LOG("mgmt", GB_LOG_ERROR, "%son host %s",
-            clnt_sperror(clnt, "block remote create failed"), host);
+            clnt_sperror(clnt, "block remote create2 call failed"), host);
         goto out;
       }
     } else {
@@ -600,7 +600,7 @@ glusterBlockCallRPC_1(char *host, void *cobj,
       *rpc_sent = TRUE;
       if (block_create_1(&cblk_v1, &reply, clnt) != RPC_SUCCESS) {
         LOG("mgmt", GB_LOG_ERROR, "%son host %s",
-            clnt_sperror(clnt, "block remote create failed"), host);
+            clnt_sperror(clnt, "block remote create call failed"), host);
         goto out;
       }
     }
@@ -609,8 +609,8 @@ glusterBlockCallRPC_1(char *host, void *cobj,
     *rpc_sent = TRUE;
     ret = block_version_1((void*)cobj, &reply, clnt);
     if (ret != RPC_SUCCESS) {
-      LOG("mgmt", GB_LOG_ERROR, "%son host %s",
-          clnt_sperror(clnt, "block remote version failed"), host);
+      LOG("mgmt", GB_LOG_WARNING, "%son host %s",
+          clnt_sperror(clnt, "block remote version check call failed"), host);
       goto out;
     }
     break;
@@ -618,7 +618,7 @@ glusterBlockCallRPC_1(char *host, void *cobj,
     *rpc_sent = TRUE;
     if (block_delete_1((blockDelete *)cobj, &reply, clnt) != RPC_SUCCESS) {
       LOG("mgmt", GB_LOG_ERROR, "%son host %s",
-          clnt_sperror(clnt, "block remote delete failed"), host);
+          clnt_sperror(clnt, "block remote delete call failed"), host);
       goto out;
     }
     break;
@@ -626,7 +626,7 @@ glusterBlockCallRPC_1(char *host, void *cobj,
     *rpc_sent = TRUE;
     if (block_modify_1((blockModify *)cobj, &reply, clnt) != RPC_SUCCESS) {
       LOG("mgmt", GB_LOG_ERROR, "%son host %s",
-          clnt_sperror(clnt, "block remote modify failed"), host);
+          clnt_sperror(clnt, "block remote modify call failed"), host);
       goto out;
     }
     break;
@@ -634,7 +634,7 @@ glusterBlockCallRPC_1(char *host, void *cobj,
     *rpc_sent = TRUE;
     if (block_modify_size_1((blockModifySize *)cobj, &reply, clnt) != RPC_SUCCESS) {
       LOG("mgmt", GB_LOG_ERROR, "%son host %s",
-          clnt_sperror(clnt, "block remote modify size failed"), host);
+          clnt_sperror(clnt, "block remote modify size call failed"), host);
       goto out;
     }
     break;
@@ -648,7 +648,7 @@ glusterBlockCallRPC_1(char *host, void *cobj,
       *rpc_sent = TRUE;
       if (block_replace_1((blockReplace *)cobj, &reply, clnt) != RPC_SUCCESS) {
         LOG("mgmt", GB_LOG_ERROR, "%son host %s",
-            clnt_sperror(clnt, "block remote replace failed"), host);
+            clnt_sperror(clnt, "block remote replace call failed"), host);
         goto out;
       }
       break;
@@ -1834,8 +1834,8 @@ glusterBlockCheckCapabilities(void* blk, operations opt, blockServerDefPtr list,
 
   errCode = glusterBlockCapabilityRemoteAsync(list, minCaps, resultCaps, &localErrMsg);
   if (errCode) {
-    LOG("mgmt", GB_LOG_ERROR, "glusterBlockCapabilityRemoteAsync() failed (%s)",
-                              localErrMsg);
+    LOG("mgmt", GB_LOG_WARNING, "glusterBlockCapabilityRemoteAsync() failed (%s)",
+                                localErrMsg);
     if (errCode == -ENOTCONN) {
       if (GB_ASPRINTF(errMsg, "Version check failed [%s] (Hint: See if all "
                       "servers are up and running gluster-blockd daemon)",

--- a/rpc/block_svc_routines.c
+++ b/rpc/block_svc_routines.c
@@ -485,7 +485,7 @@ glusterBlockGetSockaddr(char *host)
 
 static int glusterBlockHostConnect(char *host)
 {
-  int sockfd = -1;
+  int sockfd = RPC_ANYSOCK;
   int errsv = 0;
   struct addrinfo *res = NULL;
 
@@ -522,7 +522,7 @@ out:
     freeaddrinfo(res);
   }
 
-  if (sockfd != -1) {
+  if (sockfd != RPC_ANYSOCK) {
     close(sockfd);
   }
 
@@ -560,7 +560,7 @@ glusterBlockCallRPC_1(char *host, void *cobj,
 {
   CLIENT *clnt = NULL;
   int ret = -1;
-  int sockfd = -1;
+  int sockfd = RPC_ANYSOCK;
   int errsv = 0;
   size_t i;
   blockResponse reply = {0,};
@@ -688,10 +688,6 @@ glusterBlockCallRPC_1(char *host, void *cobj,
 
   if (res) {
     freeaddrinfo(res);
-  }
-
-  if (sockfd != -1) {
-    close(sockfd);
   }
 
   if (errsv) {

--- a/systemd/gluster-block-target.service.in
+++ b/systemd/gluster-block-target.service.in
@@ -12,3 +12,6 @@ Conflicts=target.service
 Requisite=glusterd.service
 BindsTo=tcmu-runner.service
 After=glusterd.service tcmu-runner.service
+
+[Service]
+TimeoutStartSec=600

--- a/systemd/gluster-blockd.service.in
+++ b/systemd/gluster-blockd.service.in
@@ -12,6 +12,7 @@ Environment="GB_LOG_LEVEL=INFO"
 EnvironmentFile=-@sysconfigdir@/gluster-blockd
 ExecStart=@prefix@/sbin/gluster-blockd --glfs-lru-count $GB_GLFS_LRU_COUNT --log-level $GB_LOG_LEVEL $GB_EXTRA_ARGS
 KillMode=process
+TimeoutStartSec=600
 
 [Install]
 WantedBy=multi-user.target

--- a/tests/glusterfs/wait-for-bricks-test.sh
+++ b/tests/glusterfs/wait-for-bricks-test.sh
@@ -1,0 +1,99 @@
+#!/bin/bash -x
+
+#This test-script tests that wait-for-bricks.sh works as expected in different cases
+exit_code=0
+source_path="../../extras"
+
+function test_success {
+        if ! "$@" ;
+        then
+                exit_code=1
+        fi
+}
+
+function test_failure {
+        if "$@" ;
+        then
+                exit_code=1
+        fi
+}
+
+#Should fail when glusterd is not running
+test_failure $source_path/wait-for-bricks.sh 10
+
+#Should succeed when gluster --mode=scriptd is running but no volumes exist
+glusterd
+test_success $source_path/wait-for-bricks.sh 10
+
+#Set brick-multiplexing off, so that we can kill bricks.
+gluster volume set all cluster.brick-multiplex off
+
+#Block hosting volumes are identified with features.shard being present for now
+#Should succeed when volumes that are not of interest are present
+gluster --mode=script volume create vol localhost.localdomain:/brick1 force
+test_success $source_path/wait-for-bricks.sh 10
+
+gluster --mode=script volume start vol
+test_success $source_path/wait-for-bricks.sh 10
+
+gluster --mode=script volume create vol2 replica 3 localhost.localdomain:/brick{2..4} force
+test_success $source_path/wait-for-bricks.sh 10
+
+gluster --mode=script volume start vol2
+test_success $source_path/wait-for-bricks.sh 10
+
+#Checking for the case when only the volume with replicate is available
+gluster --mode=script volume stop vol
+test_success $source_path/wait-for-bricks.sh 10
+gluster --mode=script volume start vol
+
+#Checking for the case where bhv is present but stopped
+gluster --mode=script volume create bhv1 replica 3 localhost.localdomain:/brick{5..7} force
+gluster --mode=script volume set bhv1 features.shard on
+test_success $source_path/wait-for-bricks.sh 10
+
+#Start bhv1 so that wait-for-bricks considers this volume
+gluster --mode=script volume start bhv1
+test_success $source_path/wait-for-bricks.sh 10
+
+#When a brick in bhv1 is down, script should fail
+kill -9 "$(gluster --mode=script --xml volume status bhv1 | grep -oPm1 "(?<=<pid>)[^<]+")"
+test_failure $source_path/wait-for-bricks.sh 10
+
+gluster --mode=script volume start bhv1 force
+#Kill a brick from non block hosting volume and the script should succeed
+kill -9 "$(gluster --mode=script --xml volume status vol2 | grep -oPm1 "(?<=<pid>)[^<]+")"
+test_success $source_path/wait-for-bricks.sh 10
+
+#Create one more block hosting volume to test that brick down in any one bhv leads to failure
+gluster --mode=script volume create bhv2 replica 3 localhost.localdomain:/brick{8..10} force
+gluster --mode=script volume set bhv2 features.shard on
+test_success $source_path/wait-for-bricks.sh 10
+
+gluster --mode=script volume start bhv2
+test_success $source_path/wait-for-bricks.sh 10
+
+kill -9 "$(gluster --mode=script --xml volume status bhv2 | grep -oPm1 "(?<=<pid>)[^<]+")"
+test_failure $source_path/wait-for-bricks.sh 10
+
+#Brick in each Block hosting volume is down
+kill -9 "$(gluster --mode=script --xml volume status bhv1 | grep -oPm1 "(?<=<pid>)[^<]+")"
+test_failure $source_path/wait-for-bricks.sh 10
+
+#1 Brick is down in 1 Block hosting volume and on the other all bricks are up
+gluster --mode=script v start bhv2 force
+test_failure $source_path/wait-for-bricks.sh 10
+
+gluster --mode=script volume start bhv1 force
+test_success $source_path/wait-for-bricks.sh 10
+
+gluster --mode=script v stop bhv1
+gluster --mode=script v stop bhv2
+gluster --mode=script v stop vol
+gluster --mode=script v stop vol2
+gluster --mode=script v delete bhv1
+gluster --mode=script v delete bhv2
+gluster --mode=script v delete vol
+gluster --mode=script v delete vol2
+killall -9 glusterd
+exit $exit_code

--- a/utils/Makefile.am
+++ b/utils/Makefile.am
@@ -4,8 +4,8 @@ libgb_la_SOURCES = common.c utils.c lru.c capabilities.c
 
 noinst_HEADERS = common.h utils.h lru.h list.h capabilities.h
 
-libgb_la_CFLAGS = $(GFAPI_CFLAGS)                                              \
-                  -DDATADIR=\"$(localstatedir)\" -DCONFDIR=\"$(sysconfigdir)\" \
+libgb_la_CFLAGS = $(GFAPI_CFLAGS) -DDATADIR=\"$(localstatedir)\"               \
+                  -DCONFDIR=\"$(GLUSTER_BLOCKD_WORKDIR)\"                      \
                   -I$(top_builddir)/ -I$(top_builddir)/rpc/rpcl
 
 libgb_la_LIBADD = $(GFAPI_LIBS)
@@ -19,9 +19,9 @@ DISTCLEANFILES = Makefile.in
 CLEANFILES = *~
 
 install-data-local:
-	$(MKDIR_P) $(DESTDIR)${sysconfigdir};                    \
-	$(INSTALL_DATA) gluster-block-caps.info                  \
-		$(DESTDIR)${sysconfigdir}/gluster-block-caps.info;
+	$(MKDIR_P) $(DESTDIR)$(GLUSTER_BLOCKD_WORKDIR);                              \
+	$(INSTALL_DATA) gluster-block-caps.info                                      \
+		$(DESTDIR)$(GLUSTER_BLOCKD_WORKDIR)/gluster-block-caps.info;
 
 uninstall-local:
-	rm -f $(DESTDIR)${sysconfigdir}/gluster-block-caps.info
+	rm -f $(DESTDIR)$(GLUSTER_BLOCKD_WORKDIR)/gluster-block-caps.info

--- a/utils/capabilities.h
+++ b/utils/capabilities.h
@@ -73,5 +73,8 @@ static const char *const gbCapabilitiesLookup[] = {
 };
 
 
+extern gbCapObj *globalCapabilities;
+
+
 int gbCapabilitiesEnumParse(const char *cap);
-int gbSetCapabilties (blockResponse **c);
+void gbSetCapabilties(void);

--- a/utils/utils.h
+++ b/utils/utils.h
@@ -40,6 +40,7 @@
 # define  GFAPI_LOG_LEVEL        7
 
 # define   DEVNULLPATH           "/dev/null"
+# define   GB_SAVECONFIG         "/etc/target/saveconfig.json"
 
 # define  GB_METADIR             "/block-meta"
 # define  GB_STOREDIR            "/block-store"


### PR DESCRIPTION
    1) 'pidof' command may not exist in all setups, so changing that
    to use 'ps' command which is available more often. If 'ps' command is
    not found in the setup it prints that the command is not available
    in the setup in the error log.
    
    2) For finding if 10 block volumes are up and running it was taking 9 seconds
    when all the bricks are up. I changed the script to reduce the number of
    gluster commands that are executed to get this time to 1 seconds.
