### PR TITLE
spec: create and package /var/log/gluster-block/

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -29,6 +29,9 @@ srpm: prep
 prep: dist
 	@mkdir -p build/rpmbuild/{BUILD,SPECS,RPMS,SRPMS,SOURCES}
 
+install-data-local:
+	mkdir -p $(DESTDIR)/$(localstatedir)/log/gluster-block
+
 uninstall-local:
 	cd $(DESTDIR)$(bindir) && rm -f gluster-block gluster-blockd
 

--- a/gluster-block.spec.in
+++ b/gluster-block.spec.in
@@ -73,6 +73,7 @@ rm -rf ${RPM_BUILD_ROOT}
 %{_sbindir}/gluster-block
 %{_sbindir}/gluster-blockd
 %{_mandir}/man8/gluster-block*.8*
+%dir %{_localstatedir}/log/gluster-block
 %if ( 0%{?_with_systemd:1} )
 %{_unitdir}/gluster-blockd.service
 %{_unitdir}/gluster-block-target.service
@@ -86,6 +87,9 @@ rm -rf ${RPM_BUILD_ROOT}
      %attr(0644,-,-) %{_sharedstatedir}/gluster-block/gluster-block-caps.info
 
 %changelog
+* Fri Sep 28 2018 Michael Adam <obnox@redhat.com>
+- create and package log directory
+
 * Tue Jul 17 2018 Prasanna Kumar Kalever <prasanna.kalever@redhat.com>
 - change install path for gluster-block-caps.info
 - add install details for wait-for-bricks.sh


### PR DESCRIPTION
Usually, the daemon creates the log directory.
But when it fails to start, and the log directory
has not been pre-created, then the client will
segfault instead of logging useful errors.

Change-Id: I55b5c9fcd2a9a97dba47e87a826606d48f8ac8bd
Signed-off-by: Michael Adam <obnox@redhat.com>
Signed-off-by: Niels de Vos <ndevos@redhat.com>