### PR TITLE
genconfig: with old blocks use first valid ipaddr from metadata as PR…

### DIFF
--- a/rpc/glfs-operations.c
+++ b/rpc/glfs-operations.c
@@ -713,6 +713,14 @@ blockGetMetaInfo(struct glfs* glfs, char* metafile, MetaInfo *info,
     *errCode = errno;
     goto out;
   }
+  if (!info->prio_path[0]) {
+    for (count = 0; count < info->nhosts; count++) {
+      if (blockhostIsValid(info->list[count]->status)) {
+        GB_STRCPYSTATIC(info->prio_path, info->list[count]->addr);
+        break;
+      }
+    }
+  }
   blockParseRSstatus(info);
 
  out:


### PR DESCRIPTION
…IOPATH

for block volumes which doesn't have PRIOPATH set (created with older -
versions, before introducing load-balance RFE), lets use first valid ip address
from metadata file as prio_path.

This will help mainatin compatibility of old block volumes with 'prio "alua"'
multipath conf recommondation.

Signed-off-by: Prasanna Kumar Kalever <prasanna.kalever@redhat.com>