### PR TITLE
systemd: clear the target config only when tcmu-runner is running

### DIFF
--- a/systemd/gluster-block-target.service.in
+++ b/systemd/gluster-block-target.service.in
@@ -14,4 +14,6 @@ BindsTo=tcmu-runner.service
 After=glusterd.service tcmu-runner.service
 
 [Service]
+ExecStop=
+ExecStop=/usr/bin/ps cax | /usr/bin/grep -wq '[t]cmu-runner' && /usr/bin/targetctl clear
 TimeoutStartSec=600


### PR DESCRIPTION
Signed-off-by: Prasanna Kumar Kalever <prasanna.kalever@redhat.com>