### PR TITLE
spec-file: fix the error in changelog date

### DIFF
--- a/gluster-block.spec.in
+++ b/gluster-block.spec.in
@@ -114,7 +114,7 @@ rm -rf ${RPM_BUILD_ROOT}
 * Fri Aug 11 2017 Prasanna Kumar Kalever <prasanna.kalever@redhat.com>
 - add wrapper target service unit
 
-* Tue Jun 22 2017 Prasanna Kumar Kalever <prasanna.kalever@redhat.com>
+* Thu Jun 22 2017 Prasanna Kumar Kalever <prasanna.kalever@redhat.com>
 - update with missing dependencies
 
 * Tue Jun 06 2017 Prasanna Kumar Kalever <prasanna.kalever@redhat.com>


### PR DESCRIPTION
RPM build errors:
    bogus date in %changelog: Tue Jun 22 2017 Prasanna Kumar Kalever <prasanna.kalever@redhat.com>

The change fixes the above warning!

Fixes: #138
Signed-off-by: Amar Tumballi <amarts@redhat.com>