### PR TITLE
Add travis-integration for build verification using docker

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,7 @@
+sudo: required
+
+service:
+- docker
+
+script:
+- docker build -f ./Dockerfile.buildtest .

--- a/Dockerfile.buildtest
+++ b/Dockerfile.buildtest
@@ -1,0 +1,28 @@
+# Dockerfile for testing the build of gluster-block
+
+# build on f27 until we have figured out the sunrpc / libtirpc thing...
+FROM fedora:27
+
+ENV BUILDDIR=/build
+RUN mkdir -p $BUILDDIR
+WORKDIR $BUILDDIR
+
+COPY . $BUILDDIR
+
+# prepare the system
+RUN true \
+ && dnf -y install \
+           git autoconf automake gcc libtool make file \
+           glusterfs-api-devel libuuid-devel json-c-devel \
+ && true
+
+# build
+RUN true \
+ && ./autogen.sh \
+ && ./configure \
+ && make \
+ && make check \
+ && make install \
+ && make clean \
+ && true
+


### PR DESCRIPTION
This uses docker in travis-ci to test the build of gluster-block.

Fixes #114.

It is a possible substitute for PR #135 and possibly a quicker alternative for https://github.com/gluster/centosci/pull/28 .

This currently only tests the build and not the test for two reasons:

* The build.t script assumes gluster-block is installed as RPM (==> should probably change or create a second flavor)
* The tests have some requirements on the kernel, so difficult to do in container...
