### PR TITLE
all: fix build warnings

### DIFF
--- a/utils/common.c
+++ b/utils/common.c
@@ -101,10 +101,10 @@ glusterBlockParseSize(const char *dom, char *value)
     }
 
     if (sizef % GB_DEFAULT_SECTOR_SIZE) {
-      MSG("The size %lld will align to sector size %d bytes\n",
+      MSG("The size %ld will align to sector size %d bytes\n",
           sizef, GB_DEFAULT_SECTOR_SIZE);
       LOG(dom, GB_LOG_ERROR,
-          "The target device size %lld is will align to the sector size %d",
+          "The target device size %ld is will align to the sector size %d",
 	  sizef, GB_DEFAULT_SECTOR_SIZE);
       sizef = round_down(sizef, GB_DEFAULT_SECTOR_SIZE);
     }

--- a/utils/utils.c
+++ b/utils/utils.c
@@ -16,8 +16,11 @@
 # include "lru.h"
 # include "config.h"
 
-
-struct gbConf gbConf = {LRU_COUNT_DEF, GB_LOG_INFO, GB_LOGDIR, '\0', '\0', '\0', '\0', '\0'};
+struct gbConf gbConf = {
+  .glfsLruCount = LRU_COUNT_DEF,
+  .logLevel = GB_LOG_INFO,
+  .logDir = GB_LOGDIR
+};
 
 const char *argp_program_version = ""                                 \
   PACKAGE_NAME" ("PACKAGE_VERSION")"                                  \


### PR DESCRIPTION
For global structure initialization, set only the fields
which are non-zero.

Fixes: #140
Signed-off-by: Amar Tumballi <amarts@redhat.com>
Reviewed-by: Prasanna Kumar Kalever <prasanna.kalever@redhat.com>
Reviewed-by: Xiubo Li <xiubli@redhat.com>