### PR TITLE
genconfig: add load-balance support

### DIFF
--- a/rpc/glfs-operations.c
+++ b/rpc/glfs-operations.c
@@ -713,14 +713,6 @@ blockGetMetaInfo(struct glfs* glfs, char* metafile, MetaInfo *info,
     *errCode = errno;
     goto out;
   }
-  if (!info->prio_path[0]) {
-    for (count = 0; count < info->nhosts; count++) {
-      if (blockhostIsValid(info->list[count]->status)) {
-        GB_STRCPYSTATIC(info->prio_path, info->list[count]->addr);
-        break;
-      }
-    }
-  }
   blockParseRSstatus(info);
 
  out:


### PR DESCRIPTION
[...]
  genconfig <volname[,volume2,volume3,...]> [enable-tpg <host>|load-balance]
        generate the block volumes target configuration.
[...]

The load-balance option will create the prio.info meta file and
set the prio path for each block created from old version automatically.

Fixes: #134

Signed-off-by: Xiubo Li <xiubli@redhat.com>