### PR TITLE
cli: add hostname parsing support

### DIFF
--- a/cli/gluster-block.c
+++ b/cli/gluster-block.c
@@ -263,8 +263,11 @@ static bool
 glusterBlockIsNameAcceptable(char *name)
 {
   int i = 0;
-  if (!name || strlen(name) >= 255)
+
+
+  if (!name || strlen(name) >= 255) {
     return FALSE;
+  }
   for (i = 0; i < strlen(name); i++) {
     if (!isalnum(name[i]) && (name[i] != '_') && (name[i] != '-'))
       return FALSE;
@@ -279,8 +282,9 @@ glusterBlockIsVolListAcceptable(char *name)
   char delim[2] = {'\0', };
 
 
-  if (!name || GB_STRDUP(tmp, name) < 0)
+  if (!name || GB_STRDUP(tmp, name) < 0) {
     return FALSE;
+  }
 
   delim[0] = GB_VOLS_DELIMITER;
   tok = strtok(tmp, delim);
@@ -300,8 +304,11 @@ static bool
 glusterBlockIsAddrAcceptable(char *addr)
 {
   int i = 0;
-  if (!addr || strlen(addr) == 0 || strlen(addr) > 255)
+
+
+  if (!addr || strlen(addr) == 0 || strlen(addr) > 255) {
     return FALSE;
+  }
   for (i = 0; i < strlen(addr); i++) {
     if (!isdigit(addr[i]) && (addr[i] != '.'))
       return FALSE;
@@ -766,23 +773,23 @@ glusterBlockReplace(int argcount, char **options, int json)
   }
 
   if (!glusterBlockIsAddrAcceptable(options[3])) {
-      MSG(stderr, "host addr (%s) should be a valid ip address\n%s\n",
-          options[3], GB_REPLACE_HELP_STR);
-      goto out;
+    MSG(stderr, "host addr (%s) should be a valid ip address\n%s\n",
+        options[3], GB_REPLACE_HELP_STR);
+    goto out;
   }
   GB_STRCPYSTATIC(robj.old_node, options[3]);
 
   if (!glusterBlockIsAddrAcceptable(options[4])) {
-      MSG(stderr, "host addr (%s) should be a valid ip address\n%s\n",
-          options[4], GB_REPLACE_HELP_STR);
-      goto out;
+    MSG(stderr, "host addr (%s) should be a valid ip address\n%s\n",
+        options[4], GB_REPLACE_HELP_STR);
+    goto out;
   }
   GB_STRCPYSTATIC(robj.new_node, options[4]);
 
   if (!strcmp(robj.old_node, robj.new_node)) {
-      MSG(stderr, "<old-node> (%s) and <new-node> (%s) cannot be same\n%s\n",
-          robj.old_node, robj.new_node, GB_REPLACE_HELP_STR);
-      goto out;
+    MSG(stderr, "<old-node> (%s) and <new-node> (%s) cannot be same\n%s\n",
+        robj.old_node, robj.new_node, GB_REPLACE_HELP_STR);
+    goto out;
   }
 
   robj.json_resp = json;
@@ -866,14 +873,14 @@ glusterBlockParseArgs(int count, char **options)
   }
 
   if (opt > 0 && opt < GB_CLI_HELP) {
-          json = jsonResponseFormatParse (options[count-1]);
-          if (json == GB_JSON_MAX) {
-            MSG(stderr, "expecting '--json*', got '%s'\n",
-                options[count-1]);
-            return -1;
-          } else if (json != GB_JSON_NONE) {
-                  count--;/*Commands don't need to handle json*/
-          }
+    json = jsonResponseFormatParse(options[count-1]);
+    if (json == GB_JSON_MAX) {
+      MSG(stderr, "expecting '--json*', got '%s'\n",
+          options[count-1]);
+      return -1;
+    } else if (json != GB_JSON_NONE) {
+      count--;/*Commands don't need to handle json*/
+    }
   }
 
   while (1) {
@@ -912,12 +919,14 @@ glusterBlockParseArgs(int count, char **options)
         LOG("cli", GB_LOG_ERROR, "%s", FAILED_REPLACE);
       }
       goto out;
+
     case GB_CLI_GENCONFIG:
       ret = glusterBlockGenConfig(count, options, json);
       if (ret) {
         LOG("cli", GB_LOG_ERROR, "%s", FAILED_GENCONFIG);
       }
       goto out;
+
     case GB_CLI_DELETE:
       ret = glusterBlockDelete(count, options, json);
       if (ret) {

--- a/rpc/block_svc_routines.c
+++ b/rpc/block_svc_routines.c
@@ -24,7 +24,6 @@
 
 # define   GB_CREATE            "create"
 # define   GB_DELETE            "delete"
-# define   GB_MSERVER_DELIMITER ","
 
 # define   GB_TGCLI_GLFS_PATH   "/backstores/user:glfs"
 # define   GB_TGCLI_GLFS        "targetcli " GB_TGCLI_GLFS_PATH
@@ -645,58 +644,6 @@ glusterBlockCallRPC_1(char *host, void *cobj,
   }
 
   return ret;
-}
-
-
-static blockServerDefPtr
-blockServerParse(char *blkServers)
-{
-  blockServerDefPtr list;
-  char *tmp;
-  char *base;
-  size_t i = 0;
-
-  if (!blkServers) {
-    return NULL;
-  }
-
-  if (GB_STRDUP(tmp, blkServers) < 0) {
-    return NULL;
-  }
-  base = tmp;
-
-  if (GB_ALLOC(list) < 0) {
-    goto out;
-  }
-
-  /* count number of servers */
-  while (*tmp) {
-    if (*tmp == ',') {
-      list->nhosts++;
-    }
-    tmp++;
-  }
-  list->nhosts++;
-  tmp = base; /* reset addr */
-
-
-  if (GB_ALLOC_N(list->hosts, list->nhosts) < 0) {
-    goto out;
-  }
-
-  for (i = 0; tmp != NULL; i++) {
-    if (GB_STRDUP(list->hosts[i], strsep(&tmp, GB_MSERVER_DELIMITER)) < 0) {
-      goto out;
-    }
-  }
-
-  GB_FREE(base);
-  return list;
-
- out:
-  GB_FREE(base);
-  blockServerDefFree(list);
-  return NULL;
 }
 
 

--- a/utils/common.c
+++ b/utils/common.c
@@ -11,6 +11,7 @@
 
 # include "common.h"
 
+# define   GB_MSERVER_DELIMITER ","
 
 enum JsonResponseFormat
 jsonResponseFormatParse(const char *opt)
@@ -315,3 +316,56 @@ blockhostIsValid(char *status)
 
   return FALSE;
 }
+
+blockServerDefPtr
+blockServerParse(char *blkServers)
+{
+  blockServerDefPtr list;
+  char *tmp;
+  char *base;
+  size_t i = 0;
+
+  if (!blkServers) {
+    return NULL;
+  }
+
+  if (GB_STRDUP(tmp, blkServers) < 0) {
+    return NULL;
+  }
+  base = tmp;
+
+  if (GB_ALLOC(list) < 0) {
+    goto out;
+  }
+
+  /* count number of servers */
+  while (*tmp) {
+    if (*tmp == ',') {
+      list->nhosts++;
+    }
+    tmp++;
+  }
+  list->nhosts++;
+  tmp = base; /* reset addr */
+
+
+  if (GB_ALLOC_N(list->hosts, list->nhosts) < 0) {
+    goto out;
+  }
+
+  for (i = 0; tmp != NULL; i++) {
+    if (GB_STRDUP(list->hosts[i], strsep(&tmp, GB_MSERVER_DELIMITER)) < 0) {
+      goto out;
+    }
+  }
+
+  GB_FREE(base);
+  return list;
+
+ out:
+  GB_FREE(base);
+  blockServerDefFree(list);
+  return NULL;
+}
+
+

--- a/utils/common.h
+++ b/utils/common.h
@@ -108,4 +108,6 @@ void blockServerDefFree(blockServerDefPtr blkServers);
 
 bool blockhostIsValid(char *status);
 
+blockServerDefPtr blockServerParse(char *blkServers);
+
 # endif /* _COMMON_H */


### PR DESCRIPTION
This will support the hostname and IP at the same time.

===== cat /etc/hosts =====

]# cat /etc/hosts
127.0.0.1   localhost localhost.localdomain localhost4 localhost4.localdomain4
::1         localhost localhost.localdomain localhost6 localhost6.localdomain6
192.168.195.160 client
192.168.195.162 rhel1
192.168.195.163 rhel2
192.168.195.164 rhel3

===== For the creation: =====

]# gluster-block create dht/block234 ha 3 prealloc full 192.168.195.162,192.168.195.163,192.168.195.164 1G
IQN: iqn.2016-12.org.gluster-block:2079da07-f801-450f-9736-2b0b206f57c2
PORTAL(S):  192.168.195.162:3260 192.168.195.163:3260 192.168.195.164:3260
RESULT: SUCCESS

]# gluster-block create dht/block235 ha 3 prealloc full rhel1,rhel2,rhel3 1G
IQN: iqn.2016-12.org.gluster-block:97bc6047-a69e-408c-8d8d-3298ddc8eb23
PORTAL(S):  192.168.195.162:3260 192.168.195.163:3260 192.168.195.164:3260
RESULT: SUCCESS

===== For the genconfig: =====

]# gluster-block genconfig dht enable-tpg 192.168.195.162
{
  "storage_objects":[
    {
...

]# gluster-block genconfig dht enable-tpg rhel1
{
  "storage_objects":[
    {
...

===== For the replace: =====

]#  gluster-block replace dht/block235 192.168.195.162 192.168.195.164
NAME: block235
CREATE SUCCESS: 192.168.195.164
DELETE SUCCESS: 192.168.195.162
REPLACE PORTAL SUCCESS ON:  192.168.195.163
RESULT: SUCCESS

]#  gluster-block replace dht/block235 rhel3 rhel1
NAME: block235
CREATE SUCCESS: 192.168.195.162
DELETE SUCCESS: 192.168.195.164
REPLACE PORTAL SKIPPED ON:  192.168.195.163
RESULT: SUCCESS

Fixed: #155
