### PR TITLE
replace: update the meta data whenever it fails to create in new node

### DIFF
--- a/rpc/block_svc_routines.c
+++ b/rpc/block_svc_routines.c
@@ -915,16 +915,15 @@ glusterBlockCreateRemote(void *data)
       LOG("mgmt", GB_LOG_ERROR, "%s hence %s for block %s on "
           "host %s volume %s", strerror(errno), FAILED_REMOTE_CREATE,
           cobj.block_name, args->addr, args->volume);
-      goto out;
     } else if (args->reply) {
       errMsg = args->reply;
       args->reply = NULL;
+      LOG("mgmt", GB_LOG_ERROR, "%s for block %s on host %s volume %s",
+          FAILED_REMOTE_CREATE, cobj.block_name, args->addr, args->volume);
     }
 
     GB_METAUPDATE_OR_GOTO(lock, args->glfs, cobj.block_name, cobj.volume,
                           ret, errMsg, out, "%s: CONFIGFAIL\n", args->addr);
-    LOG("mgmt", GB_LOG_ERROR, "%s for block %s on host %s volume %s",
-        FAILED_REMOTE_CREATE, cobj.block_name, args->addr, args->volume);
 
     ret = saveret;
     goto out;


### PR DESCRIPTION
When the rpc sending fails, will update the meta data file as CONFIGFAIL, because it has already updated the CONFIGINPROGRESS for the new node.

]# cat block-meta/block2 
VOLUME: dht
GBID: 18130119-da15-49b0-ac59-a15a9e968c1a
HA: 3
ENTRYCREATE: INPROGRESS
PRIOPATH: 192.168.195.162
SIZE: 1073741824
RINGBUFFER: 0
ENTRYCREATE: SUCCESS
192.168.195.164: CONFIGINPROGRESS
192.168.195.162: CONFIGINPROGRESS
192.168.195.163: CONFIGINPROGRESS
192.168.195.162: CONFIGSUCCESS
192.168.195.163: CONFIGSUCCESS
192.168.195.164: CONFIGSUCCESS
192.168.195.162: RPINPROGRESS
192.168.195.160: CONFIGINPROGRESS
192.168.195.163: RPINPROGRESS
192.168.195.164: CLEANUPINPROGRESS
192.168.195.160: CONFIGFAIL                  <<<==== HERE
192.168.195.164: CLEANUPSUCCESS
192.168.195.162: RPSUCCESS
192.168.195.163: RPSUCCESS
