### PR TITLE
gluster-blockd: support volfile server (discovery service) setting through Env

### DIFF
--- a/daemon/gluster-blockd.c
+++ b/daemon/gluster-blockd.c
@@ -445,6 +445,8 @@ main (int argc, char **argv)
     exit(EXIT_FAILURE);
   }
 
+  fetchGlfsVolServerFromEnv();
+
   gbCfg = glusterBlockSetupConfig(NULL);
   if (!gbCfg) {
     LOG("mgmt", GB_LOG_ERROR, "%s", "glusterBlockSetupConfig() failed");

--- a/rpc/block_svc_routines.c
+++ b/rpc/block_svc_routines.c
@@ -2706,7 +2706,11 @@ getSoObj(char *block, MetaInfo *info, blockGenConfigCli *blk)
   json_object_object_add(so_obj, "attributes", so_obj_attr);
   // }
 
-  snprintf(cfgstr, 1024, "glfs/%s@%s/block-store/%s", info->volume, blk->addr, info->gbid);
+  if (!strcmp(gbConf.volServer, "localhost")) {
+    snprintf(cfgstr, 1024, "glfs/%s@%s/block-store/%s", info->volume, blk->addr, info->gbid);
+  } else {
+    snprintf(cfgstr, 1024, "glfs/%s@%s/block-store/%s", info->volume, gbConf.volServer, info->gbid);
+  }
   json_object_object_add(so_obj, "config", GB_JSON_OBJ_TO_STR(cfgstr[0]?cfgstr:NULL));
   if (info->rb_size) {
     snprintf(control, 1024, "%s=%zu", GB_RING_BUFFER_STR, info->rb_size);

--- a/rpc/block_svc_routines.c
+++ b/rpc/block_svc_routines.c
@@ -1934,6 +1934,8 @@ glusterBlockReplaceNodeRemoteAsync(struct glfs *glfs, blockReplaceCli *blk,
     goto out;
   }
 
+  cobj->xdata.xdata_len = strlen(gbConf.volServer);
+  cobj->xdata.xdata_val = (char *) gbConf.volServer;
   GB_STRCPYSTATIC(cobj->ipaddr, blk->new_node);
   GB_STRCPYSTATIC(cobj->volume, info->volume);
   GB_STRCPYSTATIC(cobj->gbid, info->gbid);

--- a/rpc/glfs-operations.c
+++ b/rpc/glfs-operations.c
@@ -32,17 +32,17 @@ glusterBlockVolumeInit(char *volume, int *errCode, char **errMsg)
     GB_ASPRINTF (errMsg, "Not able to Initialize volume %s [%s]", volume,
                  strerror(*errCode));
     LOG("gfapi", GB_LOG_ERROR, "glfs_new(%s) from %s failed[%s]", volume,
-        "localhost", strerror(*errCode));
+        gbConf.volServer, strerror(*errCode));
     return NULL;
   }
 
-  ret = glfs_set_volfile_server(glfs, "tcp", "localhost", 24007);
+  ret = glfs_set_volfile_server(glfs, "tcp", gbConf.volServer, 24007);
   if (ret) {
     *errCode = errno;
     GB_ASPRINTF (errMsg, "Not able to add Volfile server for volume %s[%s]",
                  volume, strerror(*errCode));
     LOG("gfapi", GB_LOG_ERROR, "glfs_set_volfile_server(%s) of %s "
-        "failed[%s]", "localhost", volume, strerror(*errCode));
+        "failed[%s]", gbConf.volServer, volume, strerror(*errCode));
     goto out;
   }
 

--- a/systemd/gluster-blockd.sysconfig
+++ b/systemd/gluster-blockd.sysconfig
@@ -15,6 +15,9 @@
 # default level, uncomment it and set your level:
 #GB_LOG_LEVEL=INFO
 
+# Support setting block hosting volumes global volfile server (can be FQDN)
+# default volfile server is set to localhost
+#GB_BHV_VOLSERVER="localhost"
 
 # Expert use only, just incase if we have any extra args to pass for daemon
 #GB_EXTRA_ARGS=""

--- a/utils/utils.c
+++ b/utils/utils.c
@@ -237,6 +237,21 @@ glusterBlockLogdirCreate(void)
 }
 
 
+void fetchGlfsVolServerFromEnv()
+{
+  char *volServer;
+
+
+  volServer = getenv("GB_BHV_VOLSERVER");
+  if (!volServer) {
+    volServer = "localhost";
+  }
+  snprintf(gbConf.volServer, HOST_NAME_MAX, "%s", volServer);
+
+  LOG("mgmt", GB_LOG_INFO, "Block Hosting Volfile Server Set to: %s", gbConf.volServer);
+}
+
+
 int
 initLogging(void)
 {

--- a/utils/utils.h
+++ b/utils/utils.h
@@ -140,6 +140,7 @@ struct gbConf {
   pthread_mutex_t lock;
   char cmdhistoryLogFile[PATH_MAX];
   bool noRemoteRpc;
+  char volServer[HOST_NAME_MAX];
 };
 
 extern struct gbConf gbConf;
@@ -587,6 +588,8 @@ int blockMetaStatusEnumParse(const char *opt);
 int blockRemoteCreateRespEnumParse(const char *opt);
 
 void logTimeNow(char* buf, size_t bufSize);
+
+void fetchGlfsVolServerFromEnv(void);
 
 int initLogging(void);
 


### PR DESCRIPTION
What is it ?
---

This patch is majorly for GCS and kube use-case, where the discovery service,
whos name look like FQDN will resolve the backend volfile servers path, for
each and every block hosting volume from all the associated pods/nodes in the
cluster.

As of today gluster-blockd and tcmu-runner use localhost as volfile server
address to communicate with block hosting volumes, with this patch series we
will provide a way to set volfile server address (discovery service) of a
remote/separate gluster cluster, where the block hosting volume is running out-
side the gluster-block (daemon running) nodes.

This way, we achieve the isolation between the glusterd and gluster-blockd
daemons, and hence they both can now run in different nodes/pods.

How to use:
---
Just uncommnet below line at /etc/sysconfig/gluster-blockd and change the
value to fit discovery service name,

Ex:
\> #GB_BHV_VOLSERVER="localhost"
GB_BHV_VOLSERVER="dhcpXX-YYY.lab.github.com"

followed by restart of gluster-blockd.service to take changes into effect.
[Haven't used the dynamic config reload for a reason, mainly for cached glfs objects (see lru.c)]

Thanks to Amar Tumballi \<amarts@redhat.com\> for all the discussions
around this subject.


Signed-off-by: Prasanna Kumar Kalever \<prasanna.kalever@redhat.com\>
