### PR TITLE
coverity: fix pointless_string_compare issues

### DIFF
--- a/utils/utils.h
+++ b/utils/utils.h
@@ -149,15 +149,15 @@ extern struct gbConf gbConf;
           do {                                                         \
             FILE *fd;                                                  \
             char timestamp[GB_TIME_STRING_BUFLEN] = {0};               \
-            LOCK(gbConf.lock);                                       \
+            LOCK(gbConf.lock);                                         \
             if (level <= gbConf.logLevel) {                            \
-              if (!strcmp(str, "mgmt"))                                \
+              if ((str) == "mgmt")                                     \
                 fd = fopen (gbConf.daemonLogFile, "a");                \
-              else if (!strcmp(str, "cli"))                            \
+              else if ((str) == "cli")                                 \
                 fd = fopen (gbConf.cliLogFile, "a");                   \
-              else if (!strcmp(str, "gfapi"))                          \
+              else if ((str) == "gfapi")                               \
                 fd = fopen (gbConf.gfapiLogFile, "a");                 \
-              else if (!strcmp(str, "cmdlog"))                         \
+              else if ((str) == "cmdlog")                              \
                 fd = fopen (gbConf.cmdhistoryLogFile, "a");            \
               else                                                     \
                 fd = stderr;                                           \


### PR DESCRIPTION
LOG() macro was designed to compare for specific strings, and based
on the result, log to different log files. This was done using
'strcmp()', but was using static strings. It made sense to compare
the static string directly as they resolve to same pointer while
compiling.

With this fix, was able to resolve 58 coverity issues in one shot.

Signed-off-by: Amar Tumballi <amarts@redhat.com>