### PR TITLE
cli-timeout: make rpc-timeout as configurable option

### DIFF
--- a/cli/gluster-block.c
+++ b/cli/gluster-block.c
@@ -109,6 +109,7 @@ glusterBlockCliRPC_1(void *cobj, clioperations opt)
   blockResponse reply = {0,};
   char          errMsg[2048] = {0};
   gbConfig *conf = NULL;
+  char *cli_timeout;
 
 
   if (strlen(GB_UNIX_ADDRESS) > SUN_PATH_MAX) {
@@ -159,7 +160,12 @@ glusterBlockCliRPC_1(void *cobj, clioperations opt)
 
   TIMEOUT.tv_sec = conf->GB_CLI_TIMEOUT;
   if (!TIMEOUT.tv_sec) {
-    TIMEOUT.tv_sec = CLI_TIMEOUT_DEF;
+    cli_timeout = getenv("GB_CLI_TIMEOUT");
+    if (cli_timeout) {
+      sscanf(cli_timeout, "%ld", &TIMEOUT.tv_sec);
+    } else {
+      TIMEOUT.tv_sec = CLI_TIMEOUT_DEF;
+    }
   }
 
   switch(opt) {

--- a/daemon/gluster-blockd.c
+++ b/daemon/gluster-blockd.c
@@ -37,6 +37,8 @@
 extern const char *argp_program_version;
 static gbConfig *gbCfg;
 
+struct timeval TIMEOUT = {CLI_TIMEOUT_DEF, 0};  /* remote rpc call timeout, 5 mins */
+
 static void
 glusterBlockDHelp(void)
 {

--- a/rpc/rpcl/Makefile.am
+++ b/rpc/rpcl/Makefile.am
@@ -11,13 +11,15 @@ CLEANFILES = *~ $(BUILT_SOURCES)
 
 block.h: block.x
 	rpcgen -hM -o $(top_builddir)/rpc/rpcl/$@ $^
+	$(SED) -i '0,/#endif/s//#endif\nextern struct timeval TIMEOUT;/' \
+	          $(top_builddir)/rpc/rpcl/$@
 
 block_xdr.c: block.x
 	rpcgen -cM -o $(top_builddir)/rpc/rpcl/$@ $^
 
 block_clnt.c: block.x
 	rpcgen -lM -o $(top_builddir)/rpc/rpcl/$@ $^
-	$(SED) -i 's|TIMEOUT = { 25, 0 }|TIMEOUT = { 300, 0 }|' $(top_builddir)/rpc/rpcl/$@
+	$(SED) -i '/TIMEOUT = { 25, 0 }/d' $(top_builddir)/rpc/rpcl/$@
 
 block_svc.c: block.x
 	rpcgen -mM -o $(top_builddir)/rpc/rpcl/$@ $^

--- a/systemd/gluster-blockd.sysconfig
+++ b/systemd/gluster-blockd.sysconfig
@@ -19,5 +19,9 @@
 # default volfile server is set to localhost
 #GB_BHV_VOLSERVER="localhost"
 
+# CLI rpc timeout,
+# it is the time in seconds that cli has to wait for daemon to respond
+#GB_CLI_TIMEOUT=300
+
 # Expert use only, just incase if we have any extra args to pass for daemon
 #GB_EXTRA_ARGS=""

--- a/utils/Makefile.am
+++ b/utils/Makefile.am
@@ -10,6 +10,8 @@ libgb_la_CFLAGS = $(GFAPI_CFLAGS) -DDATADIR=\"$(localstatedir)\"               \
 
 libgb_la_LIBADD = $(GFAPI_LIBS)
 
+libgb_la_LDFLAGS = -lpthread
+
 libgb_ladir = $(includedir)/gluster-block/utils
 
 EXTRA_DIST = gluster-block-caps.info

--- a/utils/common.h
+++ b/utils/common.h
@@ -16,6 +16,7 @@
 # include "block.h"
 
 # define   GB_VOLS_DELIMITER    ','
+# define   CLI_TIMEOUT_DEF      300
 
 
 typedef struct blockServerDef {
@@ -107,5 +108,7 @@ bool isNumber(char number[]);
 void blockServerDefFree(blockServerDefPtr blkServers);
 
 bool blockhostIsValid(char *status);
+
+int glusterBlockLoadConfig(gbConfig *cfg, bool reloading);
 
 # endif /* _COMMON_H */

--- a/utils/dyn-config.c
+++ b/utils/dyn-config.c
@@ -184,6 +184,16 @@ glusterBlockConfSetOptions(gbConfig *cfg, bool reloading)
   if (cfg->GB_GLFS_LRU_COUNT) {
     glusterBlockSetLruCount(cfg->GB_GLFS_LRU_COUNT);
   }
+
+  GB_PARSE_CFG_INT(cfg, GB_CLI_TIMEOUT, CLI_TIMEOUT_DEF);
+  /* NOTE: we don't use CLI_TIMEOUT in daemon at the moment
+   * TODO: use gbConf in cli too, for logLevel/LogDir and other future options
+   *
+   * if (cfg->GB_CLI_TIMEOUT) {
+   *  glusterBlockSetCliTimeout(cfg->GB_CLI_TIMEOUT);
+   * }
+   */
+
   /* add your new config options */
 }
 
@@ -438,7 +448,7 @@ glusterBlockParseOptions(gbConfig *cfg, char *buf, int len, bool reloading)
   glusterBlockConfSetOptions(cfg, reloading);
 }
 
-static int
+int
 glusterBlockLoadConfig(gbConfig *cfg, bool reloading)
 {
   ssize_t len = 0;

--- a/utils/utils.c
+++ b/utils/utils.c
@@ -19,7 +19,8 @@
 struct gbConf gbConf = {
   .glfsLruCount = LRU_COUNT_DEF,
   .logLevel = GB_LOG_INFO,
-  .logDir = GB_LOGDIR
+  .logDir = GB_LOGDIR,
+  .cliTimeout = CLI_TIMEOUT_DEF
 };
 
 const char *argp_program_version = ""                                 \
@@ -48,6 +49,24 @@ glusterBlockSetLogLevel(unsigned int logLevel)
 
   return 0;
 }
+
+
+/* TODO: use gbConf in cli too, for logLevel/LogDir and other future options
+int
+glusterBlockSetCliTimeout(size_t timeout)
+{
+  if (timeout < 0) {
+    MSG(stderr, "unknown GB_CLI_TIMEOUT: '%zu'\n", timeout);
+    return -1;
+  }
+  LOCK(gbConf.lock);
+  gbConf.cliTimeout = timeout;
+  UNLOCK(gbConf.lock);
+
+  return 0;
+}
+*/
+
 
 int
 glusterBlockCLIOptEnumParse(const char *opt)

--- a/utils/utils.h
+++ b/utils/utils.h
@@ -57,7 +57,7 @@
 
 # define  GB_METASTORE_RESERVE   10485760   /* 10 MiB reserve for block-meta */
 
-# define  GB_DEF_CONFIGPATH      "/etc/sysconfig/gluster-blockd"; /* the default config file */
+# define  GB_DEF_CONFIGPATH      "/etc/sysconfig/gluster-blockd" /* the default config file */
 
 # define  GB_TIME_STRING_BUFLEN  \
           (4 + 1 + 2 + 1 + 2 + 1 + 2 + 1 + 2 + 1 + 2 + 1 + 6 + 1 +   5)
@@ -132,6 +132,7 @@
 struct gbConf {
   size_t glfsLruCount;
   unsigned int logLevel;
+  size_t cliTimeout;
   char logDir[PATH_MAX];
   char daemonLogFile[PATH_MAX];
   char cliLogFile[PATH_MAX];
@@ -574,9 +575,12 @@ typedef struct gbConfig {
   bool isDynamic;
   char *GB_LOG_LEVEL;
   ssize_t GB_GLFS_LRU_COUNT;
+  ssize_t GB_CLI_TIMEOUT;  /* seconds */
 } gbConfig;
 
 int glusterBlockSetLogLevel(unsigned int logLevel);
+
+//int glusterBlockSetCliTimeout(size_t timeout);
 
 int glusterBlockCLIOptEnumParse(const char *opt);
 


### PR DESCRIPTION
There are two rpc calls involved in the design,
Channel A: From cli process to local daemon (cli thread)
Channel B: From local daemon (cli thread) to remote daemon (remote thread)

Timeout for channel A is configurable now, using
/etc/sysconfig/gluster-blockd, by adjusting option 'GB_CLI_TIMEOUT' (in seconds)

$ cat /etc/sysconfig/gluster-blockd
GB_CLI_TIMEOUT=900

Changes to this value takes effect every time we start running/triggering new
cli command/request.

At the moment making Timeout configurable for channel B is not important, it is
hardcoded as 300 seconds in the code for now.                                  

Some more details:
-----------------
It would have been an easy fix calling clnt_control() right after clnt_create(),
unfortunately there is a bug in glibc, which is why we had to hack the rpc
generated code instead of directly calling clnt_control(), see my very old
commit [1] which explains why we had to override (in a hacky-way) the default
generated TIMEOUT.

[1] https://github.com/gluster/gluster-block/commit/1dbbd7d457251afd1f005bf262b5c366642535e2

Signed-off-by: Prasanna Kumar Kalever <prasanna.kalever@redhat.com>