### PR TITLE
client: set rpc timeout to 15 minutes instead of 5 minutes

### DIFF
--- a/rpc/rpcl/Makefile.am
+++ b/rpc/rpcl/Makefile.am
@@ -17,7 +17,7 @@ block_xdr.c: block.x
 
 block_clnt.c: block.x
 	rpcgen -lM -o $(top_builddir)/rpc/rpcl/$@ $^
-	$(SED) -i 's|TIMEOUT = { 25, 0 }|TIMEOUT = { 300, 0 }|' $(top_builddir)/rpc/rpcl/$@
+	$(SED) -i 's|TIMEOUT = { 25, 0 }|TIMEOUT = { 900, 0 }|' $(top_builddir)/rpc/rpcl/$@
 
 block_svc.c: block.x
 	rpcgen -mM -o $(top_builddir)/rpc/rpcl/$@ $^


### PR DESCRIPTION
For creating a very large block volume, e.g of size 2TB,
with prealloc=full, the current hard-coded client timeout
of 5 minutes is not enough.

Raising this to 15 minutes as a quick fix for situations
where it is necessary to create such a volume.

## TODO

We still need to figure out if 15 minutes is actually a good value. This was what was floating around...