### PR TITLE
Minor fixes

### DIFF
--- a/cli/gluster-block.c
+++ b/cli/gluster-block.c
@@ -580,6 +580,13 @@ glusterBlockCreate(int argcount, char **options, int json)
     case GB_CLI_CREATE_HA:
       if (isNumber(options[optind])) {
         sscanf(options[optind++], "%u", &cobj.mpath);
+        if (!cobj.mpath) {
+          MSG(stderr, "%s\n", "'ha' cannot be zero.");
+          MSG(stderr, "%s\n", GB_CREATE_HELP_STR);
+          LOG("cli", GB_LOG_ERROR, "failed parsing ha as 0 for block <%s/%s>",
+              cobj.volume, cobj.block_name);
+          goto out;
+        }
       } else {
         MSG(stderr, "%s\n", "'ha' option is incorrect");
         MSG(stderr, "%s\n", GB_CREATE_HELP_STR);

--- a/rpc/glfs-operations.c
+++ b/rpc/glfs-operations.c
@@ -774,7 +774,9 @@ blockGetPrioPath(struct glfs* glfs, char *volume, blockServerDefPtr list,
     }
   }
 
-  ret = 0;
+  if (list->nhosts) {
+    ret = 0;
+  }
 
  out:
   if (pfd && glfs_close(pfd) != 0) {


### PR DESCRIPTION
* cli: do not allow 'ha 0'
How to test:
$ gluster-block create sample/block ha 0 192.168.43.158 1MiB

* blockGetPrioPath: avoid crash when nhosts is zero
How to test:
$ touch /mnt/block-meta/block
$ gluster-block genconfig sample enable-tpg 192.168.43.158
