### PR TITLE
dyn-logger: make sure the logLevel changing log visible always

### DIFF
--- a/utils/utils.c
+++ b/utils/utils.c
@@ -44,7 +44,7 @@ glusterBlockSetLogLevel(unsigned int logLevel)
   LOCK(gbConf.lock);
   gbConf.logLevel = logLevel;
   UNLOCK(gbConf.lock);
-  LOG("mgmt", GB_LOG_INFO,
+  LOG("mgmt", GB_LOG_NONE,
       "logLevel now is %s\n", LogLevelLookup[logLevel]);
 
   return 0;


### PR DESCRIPTION
Fixes: bz#1661406
Signed-off-by: Xiubo Li <xiubli@redhat.com>