### PR TITLE
utils: fix compile warning

### DIFF
--- a/rpc/block_svc_routines.c
+++ b/rpc/block_svc_routines.c
@@ -165,6 +165,7 @@ removeDuplicateSubstr(char **line)
   char *temp = *line;
   char *out;
   char *element;
+  size_t len;
 
 
   if (!temp) {
@@ -172,7 +173,8 @@ removeDuplicateSubstr(char **line)
   }
 
   /* Allocate size for out including trailing space and \0. */
-  if (GB_ALLOC_N(out, strlen(temp) + strlen(" ") + 1) < 0) {
+  len = strlen(temp) + strlen(" ") + 1;
+  if (GB_ALLOC_N(out, len) < 0) {
     return;
   }
 
@@ -180,8 +182,8 @@ removeDuplicateSubstr(char **line)
   element = strtok(temp, " ");
   while (element) {
     if (!strstr(out, element)) {
-      strncat(out, element, strlen(element));
-      strncat(out, " ", 1);
+      GB_STRCAT(out, element, len);
+      GB_STRCAT(out, " ", 2);
     }
     element = strtok(NULL, " ");
   }

--- a/utils/dyn-config.c
+++ b/utils/dyn-config.c
@@ -233,7 +233,8 @@ glusterBlockReadConfig(gbConfig *cfg, ssize_t *len)
 {
   int save = errno;
   char *p, *buf, *line = NULL;
-  ssize_t m, n, buf_len = GB_BUF_LEN;
+  ssize_t m, buf_len = GB_BUF_LEN;
+  size_t n;
   FILE *fp;
   int i;
 

--- a/utils/utils.c
+++ b/utils/utils.c
@@ -428,11 +428,26 @@ gbStrcpy(char *dest, const char *src, size_t destbytes,
     if (n > (destbytes - 1))
       return NULL;
 
-    ret = strncpy(dest, src, n);
-    /* strncpy NULL terminates if the last character is \0.  Therefore
-     * force the last byte to be \0
-     */
+    ret = memcpy(dest, src, n);
     dest[n] = '\0';
+
+    return ret;
+}
+
+
+char *
+gbStrcat(char *dest, const char *src, size_t destbytes,
+         const char *filename, const char *funcname, size_t linenr)
+{
+    char *ret;
+    size_t n = strlen(src);
+    size_t m = strlen(dest);
+
+    if (n > (destbytes - 1))
+      return NULL;
+
+    ret = memcpy(dest + m, src, n);
+    dest[m + n] = '\0';
 
     return ret;
 }

--- a/utils/utils.h
+++ b/utils/utils.h
@@ -357,6 +357,10 @@ extern struct gbConf gbConf;
             gbStrcpy((dst), (src), (destbytes),                      \
                      __FILE__, __FUNCTION__, __LINE__)
 
+# define  GB_STRCAT(dst, src, destbytes)                             \
+            gbStrcat((dst), (src), (destbytes),                      \
+                     __FILE__, __FUNCTION__, __LINE__)
+
 # define  GB_STRCPYSTATIC(dst, src)                                  \
             GB_STRCPY((dst), (src), (sizeof(dst)))
 
@@ -621,6 +625,9 @@ int gbStrdup(char **dest, const char *src,
              const char *filename, const char *funcname, size_t linenr);
 
 char* gbStrcpy(char *dest, const char *src, size_t destbytes,
+               const char *filename, const char *funcname, size_t linenr);
+
+char *gbStrcat(char *dest, const char *src, size_t destbytes,
                const char *filename, const char *funcname, size_t linenr);
 
 void gbFree(void *ptrptr);


### PR DESCRIPTION
passing the strlen() of the source string as the destination
length is pointless, and gcc-8 now warns about it:

utils.c: In function ‘gbStrcpy’:
utils.c:432:11: warning: ‘strncpy’ specified bound depends on the
length of the source argument [-Wstringop-overflow=]
     ret = strncpy(dest, src, n);
           ^~~~~~~~~~~~~~~~~~~~~
utils.c:427:16: note: length computed here
     size_t n = strlen(src);
                ^~~~~~~~~~~

block_svc_routines.c:184:7: warning: ‘strncat’ specified bound 1
equals source length [-Wstringop-overflow=]
       strncat(out, " ", 1);
       ^~~~~~~~~~~~~~~~~~~~
block_svc_routines.c:183:7: warning: ‘strncat’ specified bound
depends on the length of the source argument [-Wstringop-overflow=]
       strncat(out, element, strlen(element));
       ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

Signed-off-by: Xiubo Li <xiubli@redhat.com>