### PR TITLE
service: update the required rpcbind service start sequence

### DIFF
--- a/systemd/gluster-blockd.service.in
+++ b/systemd/gluster-blockd.service.in
@@ -3,7 +3,7 @@ Description=Gluster block storage utility
 Requisite=glusterd.service
 Requires=rpcbind.service
 BindsTo=gluster-block-target.service
-After=gluster-block-target.service
+After=gluster-block-target.service rpcbind.service
 
 [Service]
 Type=simple


### PR DESCRIPTION
In some test case we hit that the gluster-blockd service failed
due to the rpcbind service is not up.

Signed-off-by: Xiubo Li <xiubli@redhat.com>