### PR TITLE
dyn-cfg: Avoid putting large char array on the stack

### DIFF
--- a/cli/gluster-block.c
+++ b/cli/gluster-block.c
@@ -1035,7 +1035,7 @@ main(int argc, char *argv[])
     goto fail;
   }
 
-  if(initLogging()) {
+  if(initLogging(NULL)) {
     goto fail;
   }
 

--- a/configure.ac
+++ b/configure.ac
@@ -122,6 +122,9 @@ fi
 GLUSTER_BLOCKD_LIBEXECDIR="$(eval echo ${libexecdir}/gluster-block)"
 AC_SUBST(GLUSTER_BLOCKD_LIBEXECDIR)
 
+GLUSTER_BLOCKD_LOGROTATEDIR="$(eval echo /etc/logrotate.d)"
+AC_SUBST(GLUSTER_BLOCKD_LOGROTATEDIR)
+
 # Checks for typedefs, structures, and compiler characteristics.
 AC_CHECK_HEADER_STDBOOL
 AC_TYPE_SIZE_T

--- a/daemon/gluster-blockd.c
+++ b/daemon/gluster-blockd.c
@@ -439,7 +439,7 @@ main (int argc, char **argv)
   int errnosv = 0;
 
 
-  if(initLogging()) {
+  if(initLogging("mgmt")) {
     exit(EXIT_FAILURE);
   }
 

--- a/daemon/gluster-blockd.c
+++ b/daemon/gluster-blockd.c
@@ -439,17 +439,13 @@ main (int argc, char **argv)
   int errnosv = 0;
 
 
-  if (pthread_mutex_init(&gbConf.lock, NULL) < 0) {
-    exit(EXIT_FAILURE);
-  }
-
   if(initLogging()) {
     exit(EXIT_FAILURE);
   }
 
   fetchGlfsVolServerFromEnv();
 
-  gbCfg = glusterBlockSetupConfig(NULL);
+  gbCfg = glusterBlockSetupConfig();
   if (!gbCfg) {
     LOG("mgmt", GB_LOG_ERROR, "%s", "glusterBlockSetupConfig() failed");
     return -1;

--- a/gluster-block.spec.in
+++ b/gluster-block.spec.in
@@ -81,6 +81,7 @@ rm -rf ${RPM_BUILD_ROOT}
 %attr(0755,-,-) %{_initddir}/gluster-blockd
 %endif
 %config(noreplace) %{_sysconfdir}/sysconfig/gluster-blockd
+%config(noreplace) %{_sysconfdir}/logrotate.d/gluster-block
 %dir %attr(0755,-,-) %{_libexecdir}/gluster-block
      %attr(0755,-,-) %{_libexecdir}/gluster-block/wait-for-bricks.sh
      %attr(0755,-,-) %{_libexecdir}/gluster-block/upgrade_activities.sh

--- a/systemd/Makefile.am
+++ b/systemd/Makefile.am
@@ -18,7 +18,11 @@ endif
 install-data-local:
 	$(MKDIR_P) $(DESTDIR)${sysconfigdir};              \
 	$(INSTALL_DATA) gluster-blockd.sysconfig           \
-		$(DESTDIR)${sysconfigdir}/gluster-blockd;
+		$(DESTDIR)${sysconfigdir}/gluster-blockd;  \
+	$(MKDIR_P) $(DESTDIR)$(GLUSTER_BLOCKD_LOGROTATEDIR);\
+	$(INSTALL_DATA) -m 644 gluster-block.logrotate     \
+		$(DESTDIR)$(GLUSTER_BLOCKD_LOGROTATEDIR)/gluster-block;
 
 uninstall-local:
-	rm -f $(DESTDIR)${sysconfigdir}/gluster-blockd
+	rm -f $(DESTDIR)${sysconfigdir}/gluster-blockd     \
+		$(DESTDIR)$(GLUSTER_BLOCKD_LOGROTATEDIR)/gluster-block   

--- a/systemd/gluster-block.logrotate
+++ b/systemd/gluster-block.logrotate
@@ -1,0 +1,18 @@
+# Rotate all the gluster-block logs
+/var/log/gluster-block/*.log {
+  sharedscripts
+  weekly
+  maxsize 10M
+  minsize 100k
+
+# 6 months of logs are good enough
+  rotate 26
+
+  missingok
+  compress
+  delaycompress
+  notifempty
+  postrotate
+  killall -q -s 1 gluster-blockd > /dev/null 2>&1 || true
+  endscript
+}

--- a/systemd/gluster-blockd.sysconfig
+++ b/systemd/gluster-blockd.sysconfig
@@ -10,7 +10,7 @@
 #GB_GLFS_LRU_COUNT=5
 
 
-# Supported loglevels [ NONE, ERROR, WARNING, INFO, DEBUG, TRACE ]
+# Supported loglevels [ NONE, CRIT, ERROR, WARNING, INFO, DEBUG, TRACE ]
 # And the default logging level is INFO, if you want to change the
 # default level, uncomment it and set your level:
 #GB_LOG_LEVEL=INFO

--- a/systemd/gluster-blockd.sysconfig
+++ b/systemd/gluster-blockd.sysconfig
@@ -9,7 +9,6 @@
 # least recently used object.
 #GB_GLFS_LRU_COUNT=5
 
-
 # Supported loglevels [ NONE, CRIT, ERROR, WARNING, INFO, DEBUG, TRACE ]
 # And the default logging level is INFO, if you want to change the
 # default level, uncomment it and set your level:
@@ -25,3 +24,7 @@
 
 # Expert use only, just incase if we have any extra args to pass for daemon
 #GB_EXTRA_ARGS=""
+#
+# Supported setting the log directory path from the sysconfig
+# default path is /var/log/gluster-blockd, uncomment it and set your path:
+#GB_LOG_DIR="/var/log/gluster-blockd"

--- a/utils/Makefile.am
+++ b/utils/Makefile.am
@@ -8,7 +8,7 @@ libgb_la_CFLAGS = $(GFAPI_CFLAGS) -DDATADIR=\"$(localstatedir)\"               \
                   -DCONFDIR=\"$(GLUSTER_BLOCKD_WORKDIR)\"                      \
                   -I$(top_builddir)/ -I$(top_builddir)/rpc/rpcl
 
-libgb_la_LIBADD = $(GFAPI_LIBS)
+libgb_la_LIBADD = $(PTHREAD) $(GFAPI_LIBS)
 
 libgb_la_LDFLAGS = -lpthread
 

--- a/utils/dyn-config.c
+++ b/utils/dyn-config.c
@@ -474,7 +474,7 @@ glusterBlockDynConfigStart(void *arg)
 {
   gbConfig *cfg = arg;
   int monitor, wd, len;
-  char buf[GB_BUF_LEN];
+  char *buf = NULL;
   struct inotify_event *event;
   char *p;
 
@@ -496,6 +496,11 @@ glusterBlockDynConfigStart(void *arg)
   LOG("mgmt", GB_LOG_INFO,
       "Inotify is watching \"%s\", wd: %d, mask: IN_ALL_EVENTS\n",
       cfg->configPath, wd);
+
+  if (GB_ALLOC_N(buf, GB_BUF_LEN) < 0) {
+    LOG("cmdlog", GB_LOG_ERROR, "%s", "Could not allocate memory for buf\n");
+    goto out;
+  }
 
   while (1) {
     len = read(monitor, buf, GB_BUF_LEN);
@@ -532,6 +537,9 @@ glusterBlockDynConfigStart(void *arg)
     }
   }
 
+out:
+  GB_FREE(buf);
+  inotify_rm_watch(monitor, wd);
   return NULL;
 }
 

--- a/utils/dyn-config.c
+++ b/utils/dyn-config.c
@@ -526,7 +526,10 @@ glusterBlockDynConfigStart(void *arg)
   gbConfig *cfg = arg;
   int monitor, wd, len;
   char *buf = NULL;
+  char *cfgDir = NULL;//[PATH_MAX];
   struct inotify_event *event;
+  struct timespec mtim = {0, }; /* Time of last modification.  */
+  struct stat statbuf;
   char *p;
 
 
@@ -537,16 +540,38 @@ glusterBlockDynConfigStart(void *arg)
     return NULL;
   }
 
-  wd = inotify_add_watch(monitor, cfg->configPath, IN_ALL_EVENTS);
+  if (GB_ALLOC_N(cfgDir, PATH_MAX) < 0) {
+    LOG("cmdlog", GB_LOG_ERROR, "%s", "Could not allocate memory for cfgDir\n");
+    return NULL;
+  }
+
+  snprintf(cfgDir, PATH_MAX, cfg->configPath);
+  p = strrchr(cfgDir, '/');
+  if (p) {
+      *(p + 1) = '\0';
+  } else {
+      snprintf(cfgDir, PATH_MAX, GB_DEF_CONFIGDIR);
+  }
+
+  /* Editors (vim, nano ..) follow different approaches to save conf file.
+   * The two commonly followed techniques are to overwrite the existing
+   * file, or to write to a new file (.swp, .tmp ..) and move it to actual
+   * file name later. In the later case, the inotify fails, because the
+   * file it's been intended to watch no longer exists, as the new file
+   * is a different file with just a same name.
+   * To handle both the file save approaches mentioned above, it is better
+   * we watch the directory and filter for MODIFY events.
+   */
+  wd = inotify_add_watch(monitor, cfgDir, IN_MODIFY);
+  GB_FREE(cfgDir);
   if (wd == -1) {
     LOG("mgmt", GB_LOG_ERROR,
-        "Failed to add \"%s\" to inotify (%d)\n", cfg->configPath, monitor);
+        "Failed to add \"%s\" to inotify (%d)\n", cfgDir, monitor);
     return NULL;
   }
 
   LOG("mgmt", GB_LOG_INFO,
-      "Inotify is watching \"%s\", wd: %d, mask: IN_ALL_EVENTS\n",
-      cfg->configPath, wd);
+      "Inotify is watching \"%s\", wd: %d, mask: IN_MODIFY\n", cfgDir, wd);
 
   if (GB_ALLOC_N(buf, GB_BUF_LEN) < 0) {
     LOG("cmdlog", GB_LOG_ERROR, "%s", "Could not allocate memory for buf\n");
@@ -560,7 +585,7 @@ glusterBlockDynConfigStart(void *arg)
       continue;
     }
 
-    for (p = buf; p < buf + len;) {
+    for (p = buf; p < buf + len; p += sizeof(*event) + event->len) {
       event = (struct inotify_event *)p;
 
       LOG("mgmt", GB_LOG_INFO, "event->mask: 0x%x\n", event->mask);
@@ -569,22 +594,21 @@ glusterBlockDynConfigStart(void *arg)
         continue;
       }
 
-      /*
-       * If force to write to the unwritable or crashed
-       * config file, the vi/vim will try to move and
-       * delete the config file and then recreate it again
-       * via the *.swp
-       */
-      if ((event->mask & IN_IGNORED) && !access(cfg->configPath, F_OK)) {
-        wd = inotify_add_watch(monitor, cfg->configPath, IN_ALL_EVENTS);
+      /* If stat fails we will skip the modify time check */
+      if (!stat(cfg->configPath, &statbuf)) {
+          if (statbuf.st_mtim.tv_sec == mtim.tv_sec &&
+              statbuf.st_mtim.tv_nsec == mtim.tv_nsec) {
+              continue;
+          }
       }
+
+      mtim.tv_sec = statbuf.st_mtim.tv_sec;
+      mtim.tv_nsec = statbuf.st_mtim.tv_nsec;
 
       /* Try to reload the config file */
-      if (event->mask & IN_MODIFY || event->mask & IN_IGNORED) {
-        glusterBlockLoadConfig(cfg, false);
+      if (event->mask & IN_MODIFY) {
+          glusterBlockLoadConfig(cfg, false);
       }
-
-      p += sizeof(struct inotify_event) + event->len;
     }
   }
 

--- a/utils/lru.c
+++ b/utils/lru.c
@@ -38,7 +38,7 @@ glusterBlockSetLruCount(const size_t lruCount)
   gbConf.glfsLruCount = lruCount;
   UNLOCK(gbConf.lock);
 
-  LOG("mgmt", GB_LOG_INFO,
+  LOG("mgmt", GB_LOG_CRIT,
       "glfsLruCount now is %lu\n", lruCount);
   return 0;
 }

--- a/utils/utils.c
+++ b/utils/utils.c
@@ -44,7 +44,7 @@ glusterBlockSetLogLevel(unsigned int logLevel)
   LOCK(gbConf.lock);
   gbConf.logLevel = logLevel;
   UNLOCK(gbConf.lock);
-  LOG("mgmt", GB_LOG_INFO,
+  LOG("mgmt", GB_LOG_CRIT,
       "logLevel now is %s\n", LogLevelLookup[logLevel]);
 
   return 0;

--- a/utils/utils.c
+++ b/utils/utils.c
@@ -272,12 +272,102 @@ void fetchGlfsVolServerFromEnv()
   LOG("mgmt", GB_LOG_INFO, "Block Hosting Volfile Server Set to: %s", gbConf.volServer);
 }
 
+
+static int glusterLogrotateConfigSet(const char *dom, char *logDir)
+{
+  char *buf = NULL, *line = NULL, *p;
+  int ret, m, len;
+  size_t n;
+  FILE *fp;
+
+  fp = fopen(GB_LOGROTATE_PATH, "r+");
+  if (fp == NULL) {
+    ret = -errno;
+    if (dom) {
+      LOG(dom, GB_LOG_ERROR, "Failed to open file '%s', %m\n", GB_LOGROTATE_PATH);
+    } else {
+      fprintf(stderr, "Failed to open file '%s', %m\n", GB_LOGROTATE_PATH);
+    }
+    return ret;
+  }
+
+  ret = fseek(fp, 0L, SEEK_END);
+  if (ret == -1) {
+    ret = -errno;
+    if (dom) {
+      LOG(dom, GB_LOG_ERROR, "Failed to seek file '%s', %m\n", GB_LOGROTATE_PATH);
+    } else {
+      fprintf(stderr, "Failed to seek file '%s', %m\n", GB_LOGROTATE_PATH);
+    }
+    goto error;
+  }
+
+  len = ftell(fp);
+  if (len == -1) {
+    ret = -errno;
+    if (dom) {
+      LOG(dom, GB_LOG_ERROR, "Failed to get the length of file '%s', %m\n", GB_LOGROTATE_PATH);
+    } else {
+      fprintf(stderr, "Failed to get the length of file '%s', %m\n", GB_LOGROTATE_PATH);
+    }
+    goto error;
+  }
+
+  /* to make sure we have enough size */
+  len += strlen(logDir) + 1;
+  if (GB_ALLOC_N(buf, len) < 0) {
+    ret = -ENOMEM;
+    goto error;
+  }
+
+  p = buf;
+  fseek(fp, 0L, SEEK_SET);
+  while ((m = getline(&line, &n, fp)) != -1) {
+    if (strstr(line, "*.log") && strchr(line, '{')) {
+      m = sprintf(p, "%s/*.log {\n", logDir);
+    } else {
+      m = sprintf(p, "%s", line);
+    }
+    if (m < 0) {
+      ret = m;
+      goto error;
+    }
+
+    p += m;
+  }
+  *p = '\0';
+  len = p - buf;
+
+  fseek(fp, 0L, SEEK_SET);
+  truncate(GB_LOGROTATE_PATH, 0L);
+  ret = fwrite(buf, 1, len, fp);
+  if (ret != len) {
+    if (dom) {
+      LOG(dom, GB_LOG_ERROR, "Failed to update '%s', %m\n", GB_LOGROTATE_PATH);
+    } else {
+      fprintf(stderr, "Failed to update '%s', %m\n", GB_LOGROTATE_PATH);
+    }
+    goto error;
+  }
+
+  ret = 0;
+ error:
+  if (fp) {
+    fclose(fp);
+  }
+  GB_FREE(buf);
+  GB_FREE(line);
+  return ret;
+}
+
+
 static int
-initLogDirAndFiles(char *newLogDir)
+initLogDirAndFiles(const char *dom, char *newLogDir)
 {
   char *logDir = NULL;
   char *tmpLogDir = NULL;
   int ret = 0;
+  bool def = false;
 
 
   /*
@@ -297,6 +387,7 @@ initLogDirAndFiles(char *newLogDir)
     }
 
     if (!logDir) {
+      def = true;
       logDir = GB_LOGDIR_DEF;
     }
   }
@@ -329,22 +420,27 @@ initLogDirAndFiles(char *newLogDir)
 
  unlock:
   UNLOCK(gbConf.lock);
+
+  if (!def) {
+    glusterLogrotateConfigSet(dom, gbConf.logDir);
+  }
+
   GB_FREE(tmpLogDir);
   return ret;
 }
 
 
 int
-initLogging(void)
+initLogging(const char *dom)
 {
-  return initLogDirAndFiles(NULL);
+  return initLogDirAndFiles(dom, NULL);
 }
 
 
 bool
 glusterBlockSetLogDir(char *logDir)
 {
-  return initLogDirAndFiles(logDir);
+  return initLogDirAndFiles("mgmt", logDir);
 }
 
 

--- a/utils/utils.h
+++ b/utils/utils.h
@@ -58,7 +58,8 @@
 
 # define  GB_METASTORE_RESERVE   10485760   /* 10 MiB reserve for block-meta */
 
-# define  GB_DEF_CONFIGPATH      "/etc/sysconfig/gluster-blockd" /* the default config file */
+# define  GB_DEF_CONFIGDIR       "/etc/sysconfig" /* the default config file directory */
+# define  GB_DEF_CONFIGPATH      GB_DEF_CONFIGDIR"/gluster-blockd" /* the default config file */
 
 # define  GB_TIME_STRING_BUFLEN  \
           (4 + 1 + 2 + 1 + 2 + 1 + 2 + 1 + 2 + 1 + 2 + 1 + 6 + 1 +   5)

--- a/utils/utils.h
+++ b/utils/utils.h
@@ -29,6 +29,7 @@
 
 # include  "list.h"
 
+# define  GB_LOGROTATE_PATH      "/etc/logrotate.d/gluster-block"
 # define  GB_LOGDIR_DEF          DATADIR "/log/gluster-block"
 # define  GB_INFODIR             DATADIR "/run"
 
@@ -611,7 +612,7 @@ void fetchGlfsVolServerFromEnv(void);
 
 bool glusterBlockSetLogDir(char *logDir);
 
-int initLogging(void);
+int initLogging(const char *dom);
 
 int gbRunnerExitStatus(int exitStatus);
 

--- a/utils/utils.h
+++ b/utils/utils.h
@@ -456,17 +456,19 @@ static const char *const gbDaemonCmdlineOptLookup[] = {
 
 typedef enum LogLevel {
   GB_LOG_NONE       = 0,
-  GB_LOG_ERROR      = 1,
-  GB_LOG_WARNING    = 2,
-  GB_LOG_INFO       = 3,
-  GB_LOG_DEBUG      = 4,
-  GB_LOG_TRACE      = 5,
+  GB_LOG_CRIT       = 1,
+  GB_LOG_ERROR      = 2,
+  GB_LOG_WARNING    = 3,
+  GB_LOG_INFO       = 4,
+  GB_LOG_DEBUG      = 5,
+  GB_LOG_TRACE      = 6,
 
   GB_LOG_MAX
 } LogLevel;
 
 static const char *const LogLevelLookup[] = {
   [GB_LOG_NONE]       = "NONE",
+  [GB_LOG_CRIT]       = "CRIT",
   [GB_LOG_ERROR]      = "ERROR",
   [GB_LOG_WARNING]    = "WARNING",
   [GB_LOG_INFO]       = "INFO",

--- a/utils/utils.h
+++ b/utils/utils.h
@@ -29,7 +29,7 @@
 
 # include  "list.h"
 
-# define  GB_LOGDIR              DATADIR "/log/gluster-block"
+# define  GB_LOGDIR_DEF          DATADIR "/log/gluster-block"
 # define  GB_INFODIR             DATADIR "/run"
 
 # define  GB_LOCK_FILE           GB_INFODIR "/gluster-blockd.lock"
@@ -582,6 +582,7 @@ typedef struct gbConfig {
 
   bool isDynamic;
   char *GB_LOG_LEVEL;
+  char *GB_LOG_DIR;
   ssize_t GB_GLFS_LRU_COUNT;
   ssize_t GB_CLI_TIMEOUT;  /* seconds */
 } gbConfig;
@@ -607,6 +608,8 @@ int blockRemoteCreateRespEnumParse(const char *opt);
 void logTimeNow(char* buf, size_t bufSize);
 
 void fetchGlfsVolServerFromEnv(void);
+
+bool glusterBlockSetLogDir(char *logDir);
 
 int initLogging(void);
 
@@ -634,8 +637,10 @@ char *gbStrcat(char *dest, const char *src, size_t destbytes,
 
 void gbFree(void *ptrptr);
 
+char *glusterBlockDynConfigGetLogDir(void);
+
 void glusterBlockDestroyConfig(struct gbConfig *cfg);
 
-gbConfig *glusterBlockSetupConfig(const char *path);
+gbConfig *glusterBlockSetupConfig(void);
 
 #endif  /* _UTILS_H */


### PR DESCRIPTION
If there are to many largr char array on the stack, with smaller
stack size limitation like:

There maybe "SEGFAULT, out of stack" issue.

Signed-off-by: Xiubo Li <xiubli@redhat.com>