### PR TITLE
cli: fix dereference of undefined pointer value

### DIFF
--- a/cli/gluster-block.c
+++ b/cli/gluster-block.c
@@ -152,10 +152,7 @@ glusterBlockCliRPC_1(void *cobj, clioperations opt)
 
   conf = glusterBlockCLILoadConfig();
   if (!conf) {
-      LOG("cli", GB_LOG_ERROR,
-          "glusterBlockCLILoadConfig() failed, for block %s create on volume %s"
-          " with hosts %s", create_obj->block_name, create_obj->volume,
-          create_obj->block_hosts);
+      LOG("cli", GB_LOG_ERROR, "%s", "glusterBlockCLILoadConfig() failed");
       goto out;
   }
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request! Your contribution is very much appreciated.

Here are some tips for you:

1. Split the changes up into minimal and atomic commits.
2. Please write a good description about your changes in commit message.
3. Write a meaningful PR text. Remember: one PR per feature or bugfix. If in doubt, split your patchset into multiple PRs.
-->


### What does this PR achieve? Why do we need it?


reported by scan-build:

```
gluster-block.c:158:11: warning: Dereference of undefined pointer value
          create_obj->block_hosts);
          ^~~~~~~~~~~~~~~~~~~~~~~
../utils/utils.h:176:23: note: expanded from macro 'LOG'
                      __VA_ARGS__, __FILE__, __LINE__, __FUNCTION__);  \
                      ^~~~~~~~~~~
1 warning generated.

```
Signed-off-by: Prasanna Kumar Kalever <prasanna.kalever@redhat.com>

