### PR TITLE
gluster-block: dump config key:value changes to respective log files

### DIFF
--- a/cli/gluster-block.c
+++ b/cli/gluster-block.c
@@ -45,6 +45,8 @@ extern const char *argp_program_version;
 struct timeval TIMEOUT;           /* cli process to daemon cli thread timeout */
 static size_t cliOptTimeout;
 
+gbProcessCtx gbCtx = GB_CLI_MODE; /* set process mode */
+
 typedef enum clioperations {
   CREATE_CLI = 1,
   LIST_CLI   = 2,

--- a/daemon/gluster-blockd.c
+++ b/daemon/gluster-blockd.c
@@ -34,6 +34,9 @@
 
 # define   GB_DISTRO_CHECK      "grep -P '(^ID=)' /etc/os-release"
 
+
+gbProcessCtx gbCtx = GB_DAEMON_MODE; /* set process mode */
+
 extern const char *argp_program_version;
 static gbConfig *gbCfg;
 

--- a/utils/dyn-config.c
+++ b/utils/dyn-config.c
@@ -517,7 +517,7 @@ glusterBlockDynConfigStart(void *arg)
     for (p = buf; p < buf + len; p += sizeof(*event) + event->len) {
       event = (struct inotify_event *)p;
 
-      LOG("mgmt", GB_LOG_INFO, "event->mask: 0x%x", event->mask);
+      LOG("mgmt", GB_LOG_DEBUG, "event->mask: 0x%x", event->mask);
 
       if (event->wd != wd) {
         continue;

--- a/utils/lru.c
+++ b/utils/lru.c
@@ -38,8 +38,14 @@ glusterBlockSetLruCount(const size_t lruCount)
   gbConf.glfsLruCount = lruCount;
   UNLOCK(gbConf.lock);
 
-  LOG("mgmt", GB_LOG_CRIT,
-      "glfsLruCount now is %lu", lruCount);
+  if (gbCtx == GB_CLI_MODE) {
+    LOG("cli", GB_LOG_DEBUG,
+        "glfsLruCount now is %lu", lruCount);
+  } else {
+    LOG("mgmt", GB_LOG_CRIT,
+        "glfsLruCount now is %lu", lruCount);
+  }
+
   return 0;
 }
 

--- a/utils/utils.c
+++ b/utils/utils.c
@@ -44,8 +44,14 @@ glusterBlockSetLogLevel(unsigned int logLevel)
   LOCK(gbConf.lock);
   gbConf.logLevel = logLevel;
   UNLOCK(gbConf.lock);
-  LOG("mgmt", GB_LOG_CRIT,
-      "logLevel now is %s", LogLevelLookup[logLevel]);
+
+  if (gbCtx == GB_CLI_MODE) {
+    LOG("cli", GB_LOG_DEBUG,
+        "logLevel now is %s", LogLevelLookup[logLevel]);
+  } else {
+    LOG("mgmt", GB_LOG_CRIT,
+        "logLevel now is %s", LogLevelLookup[logLevel]);
+  }
 
   return 0;
 }

--- a/utils/utils.h
+++ b/utils/utils.h
@@ -455,6 +455,16 @@ static const char *const gbDaemonCmdlineOptLookup[] = {
   [GB_DAEMON_OPT_MAX]        = NULL,
 };
 
+typedef enum gbProcessCtx {
+  GB_UNKNOWN_MODE         = 0,
+  GB_CLI_MODE             = 1,
+  GB_DAEMON_MODE          = 2,
+
+  GB_CTX_MODE_MAX
+} gbProcessCtx;
+
+extern gbProcessCtx gbCtx;
+
 typedef enum LogLevel {
   GB_LOG_NONE       = 0,
   GB_LOG_CRIT       = 1,


### PR DESCRIPTION
<!--
Thanks for sending a pull request! Your contribution is very much appreciated.

Here are some tips for you:

1. Split the changes up into minimal and atomic commits.
2. Please write a good description about your changes in commit message.
3. Write a meaningful PR text. Remember: one PR per feature or bugfix. If in doubt, split your patchset into multiple PRs.
-->

### What does this PR achieve? Why do we need it?


Problem:
-------
Currently cli process Loads Config on every operation in cli process
context. Hence log msgs:

DEBUG: logLevel now is TRACE [at utils.c+50:<glusterBlockSetLogLevel>]
DEBUG: glfsLruCount now is 5 [at lru.c+43:<glusterBlockSetLruCount>]

are dumped to gluster-blockd.log on every single cli operation. Apart
from the inotify triggers to Load Config.

Few Logs:

```
[2019-04-04 11:30:28.219482] CRIT: logLevel now is INFO [at utils.c+48 :<glusterBlockSetLogLevel>]                    
[2019-04-04 11:30:28.219572] CRIT: glfsLruCount now is 6 [at lru.c+42 :<glusterBlockSetLruCount>]                     
[2019-04-04 11:30:28.256593] INFO: event->mask: 0x2 [at dyn-config.c+519 :<glusterBlockDynConfigStart>]               
                                                                                                                      
                                                                                                                      
                                                                                                                      
[2019-04-04 11:30:42.313931] CRIT: logLevel now is INFO [at utils.c+48 :<glusterBlockSetLogLevel>]
[2019-04-04 11:30:42.314218] CRIT: glfsLruCount now is 6 [at lru.c+42 :<glusterBlockSetLruCount>]                     
[2019-04-04 11:30:42.314479] INFO: create cli request, volume=sample blockname=block4 mpath=1 blockhosts=192.168.124.7
9 authmode=0 size=1048576, rbsize=0 [at block_svc_routines.c+3855 :<block_create_cli_1_svc_st>]                       
[2019-04-04 11:30:42.499730] INFO: create request, volume=sample blockname=block4 blockhosts=192.168.124.79 filename=a
0002f6f-ad6f-4719-9101-5a9dd3324a23 authmode=0 passwd= size=1048576 [at block_svc_routines.c+4270 :<block_create_commo
n>]                                                                                                                   
[2019-04-04 11:30:42.796419] INFO: command exit code, 0 [at block_svc_routines.c+4446 :<block_create_common>]         
[2019-04-04 11:30:42.850829] INFO: Block create request satisfied for target: block4 on volume sample with given hosts
 192.168.124.79 [at block_svc_routines.c+3041 :<glusterBlockAuditRequest>]                                            
                                                                                                                      
                                                                                                                      
[2019-04-04 11:30:52.424297] CRIT: logLevel now is INFO [at utils.c+48 :<glusterBlockSetLogLevel>]                    
[2019-04-04 11:30:52.424477] CRIT: glfsLruCount now is 6 [at lru.c+42 :<glusterBlockSetLruCount>]                     
[2019-04-04 11:30:52.424651] INFO: create cli request, volume=sample blockname=block5 mpath=1 blockhosts=192.168.124.7
9 authmode=0 size=1048576, rbsize=0 [at block_svc_routines.c+3855 :<block_create_cli_1_svc_st>]
[2019-04-04 11:30:52.584573] INFO: create request, volume=sample blockname=block5 blockhosts=192.168.124.79 filename=e
ea46400-5430-42ee-acec-595af9883605 authmode=0 passwd= size=1048576 [at block_svc_routines.c+4270 :<block_create_commo
n>]
[2019-04-04 11:30:52.894273] INFO: command exit code, 0 [at block_svc_routines.c+4446 :<block_create_common>]
[2019-04-04 11:30:52.947050] INFO: Block create request satisfied for target: block5 on volume sample with given hosts
 192.168.124.79 [at block_svc_routines.c+3041 :<glusterBlockAuditRequest>]
```





Solution:
--------

Print the Key:Value config file parameters to respective log files based
on the process context.

That is,
- if cli process calls Load Config, then dump the logs to
gluster-block-cli.log (only DEBUG or higher level)
- if dameon process calls Load Config ( via DynConfig thread), then dump
the logs to gluster-blockd.log (in CRIT level)

Signed-off-by: Prasanna Kumar Kalever <prasanna.kalever@redhat.com>



### Does this PR fix issues?

<!-- This is optional, 'Fixes: #<issue-number>' lines will close the issue if the PR is merged.  -->




### Notes for the reviewer

This reduces unnecessary logs.


