### PR TITLE
Log improve

### DIFF
--- a/cli/gluster-block.c
+++ b/cli/gluster-block.c
@@ -164,10 +164,11 @@ glusterBlockCliRPC_1(void *cobj, clioperations opt)
   } else if (cliOptTimeout) {
     TIMEOUT.tv_sec = cliOptTimeout;
   } else if ((cli_timeout = getenv("GB_CLI_TIMEOUT"))) {
-    sscanf(cli_timeout, "%ld", &TIMEOUT.tv_sec);
+    sscanf(cli_timeout, "%lu", &TIMEOUT.tv_sec);
   } else {
     TIMEOUT.tv_sec = CLI_TIMEOUT_DEF;
   }
+  LOG("cli", GB_LOG_DEBUG, "cli timeout now is %lu", TIMEOUT.tv_sec);
 
   switch(opt) {
   case CREATE_CLI:

--- a/utils/dyn-config.c
+++ b/utils/dyn-config.c
@@ -180,9 +180,11 @@ glusterBlockConfSetOptions(gbConfig *cfg, bool reloading)
   }
 
   /* set lruCount option */
-  GB_PARSE_CFG_INT(cfg, GB_GLFS_LRU_COUNT, LRU_COUNT_DEF);
-  if (cfg->GB_GLFS_LRU_COUNT) {
-    glusterBlockSetLruCount(cfg->GB_GLFS_LRU_COUNT);
+  if (gbCtx != GB_CLI_MODE ) {
+    GB_PARSE_CFG_INT(cfg, GB_GLFS_LRU_COUNT, LRU_COUNT_DEF);
+    if (cfg->GB_GLFS_LRU_COUNT) {
+      glusterBlockSetLruCount(cfg->GB_GLFS_LRU_COUNT);
+    }
   }
 
   GB_PARSE_CFG_INT(cfg, GB_CLI_TIMEOUT, CLI_TIMEOUT_DEF);

--- a/utils/lru.c
+++ b/utils/lru.c
@@ -38,13 +38,8 @@ glusterBlockSetLruCount(const size_t lruCount)
   gbConf.glfsLruCount = lruCount;
   UNLOCK(gbConf.lock);
 
-  if (gbCtx == GB_CLI_MODE) {
-    LOG("cli", GB_LOG_DEBUG,
-        "glfsLruCount now is %lu", lruCount);
-  } else {
-    LOG("mgmt", GB_LOG_CRIT,
-        "glfsLruCount now is %lu", lruCount);
-  }
+  LOG("mgmt", GB_LOG_CRIT,
+      "glfsLruCount now is %lu", lruCount);
 
   return 0;
 }


### PR DESCRIPTION
<!--
Thanks for sending a pull request! Your contribution is very much appreciated.

Here are some tips for you:

1. Split the changes up into minimal and atomic commits.
2. Please write a good description about your changes in commit message.
3. Write a meaningful PR text. Remember: one PR per feature or bugfix. If in doubt, split your patchset into multiple PRs.
-->

### What does this PR achieve? Why do we need it?

* LoadConfig: don't call glusterBlockSetLruCount in cli process context

Because, we don't use LruCount in CLI context.

* cli: add log-msg for cli-timeout in DEBUG or higher level

gluster-block-cli.log:
[...]
[2019-04-05 08:20:38.738329] DEBUG: logLevel now is DEBUG [at utils.c+50 :\<glusterBlockSetLogLevel\>]
[2019-04-05 08:20:38.738515] DEBUG: cli timeout now is 300 [at gluster-block.c+171 :\<glusterBlockCliRPC_1\>] 


Signed-off-by: Prasanna Kumar Kalever <prasanna.kalever@redhat.com>


### Does this PR fix issues?

<!-- This is optional, 'Fixes: #<issue-number>' lines will close the issue if the PR is merged.  -->

### Notes for the reviewer

Log improvements.

