### PR TITLE
logger: allow without any variable argument [new]

### DIFF
--- a/cli/gluster-block.c
+++ b/cli/gluster-block.c
@@ -35,7 +35,7 @@
 # define  GB_ARGCHECK_OR_RETURN(argcount, count, cmd, helpstr)        \
           do {                                                        \
             if (argcount != count) {                                  \
-              MSG(stderr, "Inadequate arguments for %s:\n%s\n", cmd, helpstr); \
+              MSG(stderr, "Inadequate arguments for %s:\n%s", cmd, helpstr); \
               return -1;                                              \
             }                                                         \
           } while(0)
@@ -156,7 +156,7 @@ glusterBlockCliRPC_1(void *cobj, clioperations opt)
 
   conf = glusterBlockCLILoadConfig();
   if (!conf) {
-      LOG("cli", GB_LOG_ERROR, "%s", "glusterBlockCLILoadConfig() failed");
+      LOG("cli", GB_LOG_ERROR, "glusterBlockCLILoadConfig() failed");
       goto out;
   }
 
@@ -254,9 +254,9 @@ glusterBlockCliRPC_1(void *cobj, clioperations opt)
     }
   } else if (errMsg[0]) {
     LOG("cli", GB_LOG_ERROR, "%s", errMsg);
-    MSG(stderr, "%s\n", errMsg);
+    MSG(stderr, "%s", errMsg);
   } else {
-    MSG(stderr, "%s\n", "Did not receive any response from gluster-block daemon."
+    MSG(stderr, "Did not receive any response from gluster-block daemon."
         " Please check log files to find the reason");
     ret = -1;
   }
@@ -286,7 +286,7 @@ glusterBlockCliRPC_1(void *cobj, clioperations opt)
 static void
 glusterBlockHelp(void)
 {
-  MSG(stdout, "%s",
+  MSG(stdout,
       PACKAGE_NAME" ("PACKAGE_VERSION")\n"
       "usage:\n"
       "  gluster-block [timeout <seconds>] <command> <volname[/blockname]> [<args>] [--json*]\n"
@@ -408,9 +408,9 @@ glusterBlockParseVolumeBlock(char *volumeblock, char *volume, char *block,
   /* part before '/' is the volume name */
   sep = strchr(tmp, '/');
   if (!sep) {
-    MSG(stderr, "argument '<volname/blockname>'(%s) is incorrect\n",
+    MSG(stderr, "argument '<volname/blockname>'(%s) is incorrect",
         volumeblock);
-    MSG(stderr, "%s\n", helpstr);
+    MSG(stderr, "%s", helpstr);
     LOG("cli", GB_LOG_ERROR, "%s failed while parsing <volname/blockname>", op);
     goto out;
   }
@@ -418,13 +418,13 @@ glusterBlockParseVolumeBlock(char *volumeblock, char *volume, char *block,
 
   if (!glusterBlockIsNameAcceptable(tmp)) {
     MSG(stderr, "volume name(%s) should contain only aplhanumeric,'-', '_' characters "
-        "and should be less than 255 characters long\n", volume);
+        "and should be less than 255 characters long", volume);
     goto out;
   }
   /* part after / is blockname */
   if (!glusterBlockIsNameAcceptable(sep+1)) {
     MSG(stderr, "block name(%s) should contain only aplhanumeric,'-', '_' characters "
-        "and should be less than 255 characters long\n", block);
+        "and should be less than 255 characters long", block);
     goto out;
   }
   GB_STRCPY(volume, tmp, vol_len);
@@ -447,7 +447,7 @@ getCommandString(char **cmd, int argcount, char **options)
   }
 
   if (GB_ALLOC_N(*cmd, (total_length + 1))) {
-    LOG("cmdlog", GB_LOG_ERROR, "%s", "Could not allocate memory for command string");
+    LOG("cmdlog", GB_LOG_ERROR, "Could not allocate memory for command string");
     return;
   }
   for (i = 1; i < argcount; i++) {
@@ -469,7 +469,7 @@ glusterBlockModify(int argcount, char **options, int json)
 
 
   if (argcount < 4 || argcount > 5) {
-    MSG(stderr, "Inadequate arguments for modify:\n%s\n", GB_MODIFY_HELP_STR);
+    MSG(stderr, "Inadequate arguments for modify:\n%s", GB_MODIFY_HELP_STR);
     return -1;
   }
 
@@ -486,15 +486,15 @@ glusterBlockModify(int argcount, char **options, int json)
     if(ret >= 0) {
       mobj.auth_mode = ret;
     } else {
-      MSG(stderr, "%s\n", "'auth' option is incorrect");
-      MSG(stderr, "%s\n", GB_MODIFY_HELP_STR);
+      MSG(stderr, "'auth' option is incorrect");
+      MSG(stderr, GB_MODIFY_HELP_STR);
       LOG("cli", GB_LOG_ERROR, "Modify failed while parsing argument "
                                "to auth  for <%s/%s>", volume, block);
       goto out;
     }
 
     if ((argcount - optind)) {
-      MSG(stderr, "unknown/unsupported option '%s' for modify auth:\n%s\n",
+      MSG(stderr, "unknown/unsupported option '%s' for modify auth:\n%s",
           options[optind], GB_MODIFY_HELP_STR);
       ret = -1;
       goto out;
@@ -514,8 +514,8 @@ glusterBlockModify(int argcount, char **options, int json)
     optind++;
     sparse_ret = glusterBlockParseSize("cli", options[optind++]);
     if (sparse_ret < 0) {
-      MSG(stderr, "%s\n", "'<size>' is incorrect");
-      MSG(stderr, "%s\n", GB_MODIFY_HELP_STR);
+      MSG(stderr, "'<size>' is incorrect");
+      MSG(stderr, GB_MODIFY_HELP_STR);
       LOG("cli", GB_LOG_ERROR, "Modify failed while parsing size for block <%s/%s>",
           volume, block);
       goto out;
@@ -527,7 +527,7 @@ glusterBlockModify(int argcount, char **options, int json)
     }
 
     if ((argcount - optind)) {
-      MSG(stderr, "unknown option '%s' for modify size:\n%s\n",
+      MSG(stderr, "unknown option '%s' for modify size:\n%s",
           options[optind], GB_MODIFY_HELP_STR);
       ret = -1;
       goto out;
@@ -546,7 +546,7 @@ glusterBlockModify(int argcount, char **options, int json)
           msobj.block_name, msobj.volume);
     }
   } else {
-    MSG(stderr, "unknown option '%s' for modify:\n%s\n",
+    MSG(stderr, "unknown option '%s' for modify:\n%s",
         options[optind], GB_MODIFY_HELP_STR);
     ret = -1;
   }
@@ -570,7 +570,7 @@ glusterBlockCreate(int argcount, char **options, int json)
 
 
   if (argcount <= optind) {
-    MSG(stderr, "Inadequate arguments for create:\n%s\n", GB_CREATE_HELP_STR);
+    MSG(stderr, "Inadequate arguments for create:\n%s", GB_CREATE_HELP_STR);
     return -1;
   }
   /* set defaults */
@@ -590,15 +590,15 @@ glusterBlockCreate(int argcount, char **options, int json)
       if (isNumber(options[optind])) {
         sscanf(options[optind++], "%u", &cobj.mpath);
         if (!cobj.mpath) {
-          MSG(stderr, "%s\n", "'ha' cannot be zero.");
-          MSG(stderr, "%s\n", GB_CREATE_HELP_STR);
+          MSG(stderr, "'ha' cannot be zero.");
+          MSG(stderr, GB_CREATE_HELP_STR);
           LOG("cli", GB_LOG_ERROR, "failed parsing ha as 0 for block <%s/%s>",
               cobj.volume, cobj.block_name);
           goto out;
         }
       } else {
-        MSG(stderr, "%s\n", "'ha' option is incorrect");
-        MSG(stderr, "%s\n", GB_CREATE_HELP_STR);
+        MSG(stderr, "'ha' option is incorrect");
+        MSG(stderr, GB_CREATE_HELP_STR);
         LOG("cli", GB_LOG_ERROR, "failed while parsing ha for block <%s/%s>",
             cobj.volume, cobj.block_name);
         goto out;
@@ -609,8 +609,8 @@ glusterBlockCreate(int argcount, char **options, int json)
       if(ret >= 0) {
         cobj.auth_mode = ret;
       } else {
-        MSG(stderr, "%s\n", "'auth' option is incorrect");
-        MSG(stderr, "%s\n", GB_CREATE_HELP_STR);
+        MSG(stderr, "'auth' option is incorrect");
+        MSG(stderr, GB_CREATE_HELP_STR);
         LOG("cli", GB_LOG_ERROR, "Create failed while parsing argument "
                                  "to auth  for <%s/%s>",
                                  cobj.volume, cobj.block_name);
@@ -623,8 +623,8 @@ glusterBlockCreate(int argcount, char **options, int json)
         cobj.prealloc = ret;
         PREALLOC_OPT=true;
       } else {
-        MSG(stderr, "%s\n", "'prealloc' option is incorrect");
-        MSG(stderr, "%s\n", GB_CREATE_HELP_STR);
+        MSG(stderr, "'prealloc' option is incorrect");
+        MSG(stderr, GB_CREATE_HELP_STR);
         LOG("cli", GB_LOG_ERROR, "Create failed while parsing argument "
                                  "to prealloc  for <%s/%s>",
                                  cobj.volume, cobj.block_name);
@@ -639,16 +639,16 @@ glusterBlockCreate(int argcount, char **options, int json)
       if (isNumber(options[optind])) {
         sscanf(options[optind++], "%u", &cobj.rb_size);
         if (cobj.rb_size < 1 || cobj.rb_size > 64) {
-          MSG(stderr, "%s\n", "'ring-buffer' should be in range [1MB - 64MB]");
-          MSG(stderr, "%s\n", GB_CREATE_HELP_STR);
+          MSG(stderr, "'ring-buffer' should be in range [1MB - 64MB]");
+          MSG(stderr, GB_CREATE_HELP_STR);
           LOG("cli", GB_LOG_ERROR,
               "failed while parsing ring-buffer range [1MB - 64MB] for block <%s/%s>",
               cobj.volume, cobj.block_name);
         goto out;
         }
       } else {
-        MSG(stderr, "%s\n", "'ring-buffer' option is incorrect, hint: should be uint type");
-        MSG(stderr, "%s\n", GB_CREATE_HELP_STR);
+        MSG(stderr, "'ring-buffer' option is incorrect, hint: should be uint type");
+        MSG(stderr, GB_CREATE_HELP_STR);
         LOG("cli", GB_LOG_ERROR, "failed while parsing ring-buffer for block <%s/%s>",
             cobj.volume, cobj.block_name);
         goto out;
@@ -659,7 +659,7 @@ glusterBlockCreate(int argcount, char **options, int json)
 
   if (TAKE_SIZE) {
     if (argcount - optind != 2) {
-      MSG(stderr, "Inadequate arguments for create:\n%s\n", GB_CREATE_HELP_STR);
+      MSG(stderr, "Inadequate arguments for create:\n%s", GB_CREATE_HELP_STR);
       LOG("cli", GB_LOG_ERROR,
           "failed with Inadequate args for create block %s on volume %s with hosts %s",
           cobj.block_name, cobj.volume, cobj.block_hosts);
@@ -667,8 +667,8 @@ glusterBlockCreate(int argcount, char **options, int json)
     }
   } else {
     if (PREALLOC_OPT) {
-      MSG(stderr, "Inadequate arguments for create:\n%s\n", GB_CREATE_HELP_STR);
-      MSG(stderr, "%s\n", "Hint: do not use [prealloc <full|no>] in combination with [storage <filename>] option");
+      MSG(stderr, "Inadequate arguments for create:\n%s", GB_CREATE_HELP_STR);
+      MSG(stderr, "Hint: do not use [prealloc <full|no>] in combination with [storage <filename>] option");
       LOG("cli", GB_LOG_ERROR,
           "failed with Inadequate args for create block %s on volume %s with hosts %s",
           cobj.block_name, cobj.volume, cobj.block_hosts);
@@ -676,8 +676,8 @@ glusterBlockCreate(int argcount, char **options, int json)
     }
 
     if (argcount - optind != 1) {
-      MSG(stderr, "Inadequate arguments for create:\n%s\n", GB_CREATE_HELP_STR);
-      MSG(stderr, "%s\n", "Hint: do not use [size] in combination with [storage <filename>] option");
+      MSG(stderr, "Inadequate arguments for create:\n%s", GB_CREATE_HELP_STR);
+      MSG(stderr, "Hint: do not use [size] in combination with [storage <filename>] option");
       LOG("cli", GB_LOG_ERROR,
           "failed with Inadequate args for create block %s on volume %s with hosts %s",
           cobj.block_name, cobj.volume, cobj.block_hosts);
@@ -694,8 +694,8 @@ glusterBlockCreate(int argcount, char **options, int json)
   if (TAKE_SIZE) {
     sparse_ret = glusterBlockParseSize("cli", options[optind]);
     if (sparse_ret < 0) {
-      MSG(stderr, "%s\n", "'[size]' is incorrect");
-      MSG(stderr, "%s\n", GB_CREATE_HELP_STR);
+      MSG(stderr, "'[size]' is incorrect");
+      MSG(stderr, GB_CREATE_HELP_STR);
       LOG("cli", GB_LOG_ERROR, "failed while parsing size for block <%s/%s>",
           cobj.volume, cobj.block_name);
       goto out;
@@ -750,7 +750,7 @@ glusterBlockDelete(int argcount, char **options, int json)
 
 
   if (argcount < 2 || argcount > 5) {
-    MSG(stderr, "Inadequate arguments for delete:\n%s\n", GB_DELETE_HELP_STR);
+    MSG(stderr, "Inadequate arguments for delete:\n%s", GB_DELETE_HELP_STR);
     return -1;
   }
 
@@ -772,8 +772,8 @@ glusterBlockDelete(int argcount, char **options, int json)
     if(ret >= 0) {
       dobj.unlink = ret;
     } else {
-      MSG(stderr, "%s\n", "'unlink-storage' option is incorrect");
-      MSG(stderr, "%s\n", GB_DELETE_HELP_STR);
+      MSG(stderr, "'unlink-storage' option is incorrect");
+      MSG(stderr, GB_DELETE_HELP_STR);
       LOG("cli", GB_LOG_ERROR, "Delete failed while parsing argument "
                                "to unlink-storage  for <%s/%s>",
                                dobj.volume, dobj.block_name);
@@ -787,7 +787,7 @@ glusterBlockDelete(int argcount, char **options, int json)
   }
 
   if (argcount - optind) {
-    MSG(stderr, "Unknown option: '%s'\n%s\n", options[optind], GB_DELETE_HELP_STR);
+    MSG(stderr, "Unknown option: '%s'\n%s", options[optind], GB_DELETE_HELP_STR);
     LOG("cli", GB_LOG_ERROR, "Delete failed parsing argument unknow option '%s'"
         " for <%s/%s>", options[optind], dobj.volume, dobj.block_name);
     goto out;
@@ -846,7 +846,7 @@ glusterBlockReplace(int argcount, char **options, int json)
 
 
   if (argcount < 4 || argcount > 5) {
-    MSG(stderr, "Inadequate arguments for replace:\n%s\n", GB_REPLACE_HELP_STR);
+    MSG(stderr, "Inadequate arguments for replace:\n%s", GB_REPLACE_HELP_STR);
     return -1;
   }
 
@@ -857,21 +857,21 @@ glusterBlockReplace(int argcount, char **options, int json)
   }
 
   if (!glusterBlockIsAddrAcceptable(options[optind])) {
-    MSG(stderr, "host addr (%s) should be a valid ip address\n%s\n",
+    MSG(stderr, "host addr (%s) should be a valid ip address\n%s",
         options[optind], GB_REPLACE_HELP_STR);
     goto out;
   }
   GB_STRCPYSTATIC(robj.old_node, options[optind++]);
 
   if (!glusterBlockIsAddrAcceptable(options[optind])) {
-    MSG(stderr, "host addr (%s) should be a valid ip address\n%s\n",
+    MSG(stderr, "host addr (%s) should be a valid ip address\n%s",
         options[optind], GB_REPLACE_HELP_STR);
     goto out;
   }
   GB_STRCPYSTATIC(robj.new_node, options[optind++]);
 
   if (!strcmp(robj.old_node, robj.new_node)) {
-    MSG(stderr, "<old-node> (%s) and <new-node> (%s) cannot be same\n%s\n",
+    MSG(stderr, "<old-node> (%s) and <new-node> (%s) cannot be same\n%s",
         robj.old_node, robj.new_node, GB_REPLACE_HELP_STR);
     goto out;
   }
@@ -880,7 +880,7 @@ glusterBlockReplace(int argcount, char **options, int json)
 
   if (argcount == 5) {
     if (strcmp(options[optind], "force")) {
-      MSG(stderr, "unknown option '%s' for replace:\n%s\n", options[optind], GB_REPLACE_HELP_STR);
+      MSG(stderr, "unknown option '%s' for replace:\n%s", options[optind], GB_REPLACE_HELP_STR);
       return -1;
     } else {
       robj.force = true;
@@ -912,7 +912,7 @@ glusterBlockGenConfig(int argcount, char **options, int json)
   GB_ARGCHECK_OR_RETURN(argcount, 4, "genconfig", GB_GENCONF_HELP_STR);
 
   if (!glusterBlockIsVolListAcceptable(options[optind])) {
-    MSG(stderr, "volume list(%s) should be delimited by '%c' character only\n%s\n",
+    MSG(stderr, "volume list(%s) should be delimited by '%c' character only\n%s",
         options[optind], GB_VOLS_DELIMITER, GB_GENCONF_HELP_STR);
     goto out;
   }
@@ -921,13 +921,13 @@ glusterBlockGenConfig(int argcount, char **options, int json)
 
   if (!strcmp(options[optind++], "enable-tpg")) {
     if (!glusterBlockIsAddrAcceptable(options[optind])) {
-      MSG(stderr, "host addr (%s) should be a valid ip address\n%s\n",
+      MSG(stderr, "host addr (%s) should be a valid ip address\n%s",
           options[optind -1], GB_REPLACE_HELP_STR);
       goto out;
     }
     GB_STRCPYSTATIC(robj.addr, options[optind]);
   } else {
-      MSG(stderr, "unknown option '%s' for genconfig:\n%s\n", options[optind -1], GB_GENCONF_HELP_STR);
+      MSG(stderr, "unknown option '%s' for genconfig:\n%s", options[optind -1], GB_GENCONF_HELP_STR);
       return -1;
   }
   robj.json_resp = json;
@@ -954,49 +954,49 @@ glusterBlockParseArgs(int count, char **options, size_t opt, int json)
     case GB_CLI_CREATE:
       ret = glusterBlockCreate(count, options, json);
       if (ret && ret != EEXIST) {
-        LOG("cli", GB_LOG_ERROR, "%s", FAILED_CREATE);
+        LOG("cli", GB_LOG_ERROR, FAILED_CREATE);
       }
       goto out;
 
     case GB_CLI_LIST:
       ret = glusterBlockList(count, options, json);
       if (ret) {
-        LOG("cli", GB_LOG_ERROR, "%s", FAILED_LIST);
+        LOG("cli", GB_LOG_ERROR, FAILED_LIST);
       }
       goto out;
 
     case GB_CLI_INFO:
       ret = glusterBlockInfo(count, options, json);
       if (ret) {
-        LOG("cli", GB_LOG_ERROR, "%s", FAILED_INFO);
+        LOG("cli", GB_LOG_ERROR, FAILED_INFO);
       }
       goto out;
 
     case GB_CLI_MODIFY:
       ret = glusterBlockModify(count, options, json);
       if (ret) {
-        LOG("cli", GB_LOG_ERROR, "%s", FAILED_MODIFY);
+        LOG("cli", GB_LOG_ERROR, FAILED_MODIFY);
       }
       goto out;
 
     case GB_CLI_REPLACE:
       ret = glusterBlockReplace(count, options, json);
       if (ret) {
-        LOG("cli", GB_LOG_ERROR, "%s", FAILED_REPLACE);
+        LOG("cli", GB_LOG_ERROR, FAILED_REPLACE);
       }
       goto out;
 
     case GB_CLI_GENCONFIG:
       ret = glusterBlockGenConfig(count, options, json);
       if (ret) {
-        LOG("cli", GB_LOG_ERROR, "%s", FAILED_GENCONFIG);
+        LOG("cli", GB_LOG_ERROR, FAILED_GENCONFIG);
       }
       goto out;
 
     case GB_CLI_DELETE:
       ret = glusterBlockDelete(count, options, json);
       if (ret) {
-        LOG("cli", GB_LOG_ERROR, "%s", FAILED_DELETE);
+        LOG("cli", GB_LOG_ERROR, FAILED_DELETE);
       }
       goto out;
 
@@ -1009,7 +1009,7 @@ glusterBlockParseArgs(int count, char **options, size_t opt, int json)
 
     case GB_CLI_VERSION:
     case GB_CLI_HYPHEN_VERSION:
-      MSG(stdout, "%s\n", argp_program_version);
+      MSG(stdout, "%s", argp_program_version);
       goto out;
 
     default:
@@ -1044,7 +1044,7 @@ main(int argc, char *argv[])
   while (1) {
     opt = glusterBlockCLIOptEnumParse(argv[count]);
     if (opt < 1 || opt >= GB_CLI_OPT_MAX) {
-      MSG(stderr, "Unknown option: %s\n", argv[count]);
+      MSG(stderr, "Unknown option: %s", argv[count]);
       goto fail;
     }
     if (opt == GB_CLI_TIMEOUT) {
@@ -1056,8 +1056,8 @@ main(int argc, char *argv[])
       if (isNumber(argv[2])) {
         sscanf(argv[2], "%ld", &cliOptTimeout);
       } else {
-        MSG(stderr, "%s\n", "'timeout' option is incorrect, check usage.");
-        MSG(stderr, "%s\n", "hint: timeout argument accept only time in seconds.");
+        MSG(stderr, "'timeout' option is incorrect, check usage.");
+        MSG(stderr, "hint: timeout argument accept only time in seconds.");
         goto fail;
       }
       args = args - 2;
@@ -1067,7 +1067,7 @@ main(int argc, char *argv[])
 
     json = jsonResponseFormatParse(argv[argc-1]);
     if (json == GB_JSON_MAX) {
-      MSG(stderr, "expecting '--json*', got '%s'\n",
+      MSG(stderr, "expecting '--json*', got '%s'",
           argv[argc-1]);
       return -1;
     } else if (json != GB_JSON_NONE) {

--- a/daemon/gluster-blockd.c
+++ b/daemon/gluster-blockd.c
@@ -103,7 +103,7 @@ onSigCliHandler(int signum)
 static void
 glusterBlockDHelp(void)
 {
-  MSG(stdout, "%s",
+  MSG(stdout,
       "gluster-blockd ("PACKAGE_VERSION")\n"
       "usage:\n"
       "  gluster-blockd [--glfs-lru-count <COUNT>]\n"
@@ -123,7 +123,6 @@ glusterBlockDHelp(void)
       "        Show this message and exit.\n"
       "  --version\n"
       "        Show version info and exit.\n"
-      "\n"
      );
 }
 
@@ -265,7 +264,7 @@ glusterBlockServerProcess(void)
 
   if (errMsg[0]) {
     LOG ("mgmt", GB_LOG_ERROR, "%s", errMsg);
-    MSG(stderr, "%s\n", errMsg);
+    MSG(stderr, "%s", errMsg);
     exit(EXIT_FAILURE);
   }
 
@@ -286,7 +285,7 @@ glusterBlockDParseArgs(int count, char **options)
   while (optind < count) {
     opt = glusterBlockDaemonOptEnumParse(options[optind++]);
     if (!opt || opt >= GB_DAEMON_OPT_MAX) {
-      MSG(stderr, "unknown option: %s\n", options[optind-1]);
+      MSG(stderr, "unknown option: %s", options[optind-1]);
       return -1;
     }
 
@@ -294,7 +293,7 @@ glusterBlockDParseArgs(int count, char **options)
     case GB_DAEMON_HELP:
     case GB_DAEMON_USAGE:
       if (count != 2) {
-        MSG(stderr, "undesired options for: '%s'\n", options[optind-1]);
+        MSG(stderr, "undesired options for: '%s'", options[optind-1]);
         ret = -1;
       }
       glusterBlockDHelp();
@@ -302,19 +301,19 @@ glusterBlockDParseArgs(int count, char **options)
 
     case GB_DAEMON_VERSION:
       if (count != 2) {
-        MSG(stderr, "undesired options for: '%s'\n", options[optind-1]);
+        MSG(stderr, "undesired options for: '%s'", options[optind-1]);
         ret = -1;
       }
-      MSG(stdout, "%s\n", argp_program_version);
+      MSG(stdout, "%s", argp_program_version);
       exit(ret);
 
     case GB_DAEMON_GLFS_LRU_COUNT:
       if (count - optind  < 1) {
-        MSG(stderr, "option '%s' needs argument <COUNT>\n", options[optind-1]);
+        MSG(stderr, "option '%s' needs argument <COUNT>", options[optind-1]);
         return -1;
       }
       if (sscanf(options[optind], "%zu", &lruCount) != 1) {
-        MSG(stderr, "option '%s' expect argument type integer <COUNT>\n",
+        MSG(stderr, "option '%s' expect argument type integer <COUNT>",
             options[optind-1]);
         return -1;
       }
@@ -326,7 +325,7 @@ glusterBlockDParseArgs(int count, char **options)
 
     case GB_DAEMON_LOG_LEVEL:
       if (count - optind  < 1) {
-        MSG(stderr, "option '%s' needs argument <LOG-LEVEL>\n", options[optind-1]);
+        MSG(stderr, "option '%s' needs argument <LOG-LEVEL>", options[optind-1]);
         return -1;
       }
       logLevel = blockLogLevelEnumParse(options[optind]);
@@ -515,8 +514,7 @@ gbDependenciesVersionCheck(void)
 
  out:
   GB_FREE(out);
-  LOG("mgmt", GB_LOG_ERROR, "%s",
-      "Please install the recommended dependency version and try again.");
+  LOG("mgmt", GB_LOG_ERROR, "Please install the recommended dependency version and try again.");
   exit(EXIT_FAILURE);
 }
 
@@ -531,18 +529,18 @@ blockNodeSanityCheck(void)
   /* Check if tcmu-runner is running */
   ret = gbRunner("ps aux ww | grep -w '[t]cmu-runner' > /dev/null");
   if (ret) {
-    LOG("mgmt", GB_LOG_ERROR, "%s", "tcmu-runner not running");
+    LOG("mgmt", GB_LOG_ERROR, "tcmu-runner not running");
     return ESRCH;
   }
 
   /* Check targetcli has user:glfs handler listed */
   ret = gbRunner("targetcli /backstores/user:glfs ls > /dev/null");
   if (ret == EKEYEXPIRED) {
-    LOG("mgmt", GB_LOG_ERROR, "%s",
+    LOG("mgmt", GB_LOG_ERROR,
         "targetcli not found, please install targetcli and try again.");
     return EKEYEXPIRED;
   } else if (ret) {
-    LOG("mgmt", GB_LOG_ERROR, "%s",
+    LOG("mgmt", GB_LOG_ERROR,
         "tcmu-runner running, but targetcli doesn't list user:glfs handler");
     return  ENODEV;
   }
@@ -560,7 +558,7 @@ blockNodeSanityCheck(void)
   ret = gbRunner(global_opts);
   GB_FREE(global_opts);
   if (ret) {
-    LOG("mgmt", GB_LOG_ERROR, "%s", "targetcli set global attr failed");
+    LOG("mgmt", GB_LOG_ERROR, "targetcli set global attr failed");
     return  -1;
   }
 
@@ -574,7 +572,7 @@ initDaemonCapabilities(void)
 
   gbSetCapabilties();
   if (!globalCapabilities) {
-    LOG("mgmt", GB_LOG_ERROR, "%s", "capabilities fetching failed");
+    LOG("mgmt", GB_LOG_ERROR, "capabilities fetching failed");
     return -1;
   }
 
@@ -601,12 +599,12 @@ main (int argc, char **argv)
 
   gbCfg = glusterBlockSetupConfig(NULL);
   if (!gbCfg) {
-    LOG("mgmt", GB_LOG_ERROR, "%s", "glusterBlockSetupConfig() failed");
+    LOG("mgmt", GB_LOG_ERROR, "glusterBlockSetupConfig() failed");
     exit(EXIT_FAILURE);
   }
 
   if (glusterBlockDParseArgs(argc, argv)) {
-    LOG("mgmt", GB_LOG_ERROR, "%s", "glusterBlockDParseArgs() failed");
+    LOG("mgmt", GB_LOG_ERROR, "glusterBlockDParseArgs() failed");
     goto out;
   }
 
@@ -620,8 +618,7 @@ main (int argc, char **argv)
 
   lock.l_type = F_WRLCK;
   if (fcntl(ctx.pfd, F_SETLK, &lock) == -1) {
-    LOG("mgmt", GB_LOG_ERROR, "%s",
-        "gluster-blockd is already running...");
+    LOG("mgmt", GB_LOG_ERROR, "gluster-blockd is already running...");
     goto out;
   }
 
@@ -633,9 +630,9 @@ main (int argc, char **argv)
     if (initDaemonCapabilities()) {
       goto out;
     }
-    LOG("mgmt", GB_LOG_INFO, "%s", "capabilities fetched successfully");
+    LOG("mgmt", GB_LOG_INFO, "capabilities fetched successfully");
   } else {
-    LOG("mgmt", GB_LOG_DEBUG, "%s", "gluster-blockd running in noRemoteRpc mode");
+    LOG("mgmt", GB_LOG_DEBUG, "gluster-blockd running in noRemoteRpc mode");
   }
 
   initCache();
@@ -681,7 +678,7 @@ main (int argc, char **argv)
       LOG("mgmt", GB_LOG_DEBUG,
           "exit status of server process was (%d)", WEXITSTATUS(wstatus));
 
-      LOG("mgmt", GB_LOG_CRIT, "%s", "Exiting ...");
+      LOG("mgmt", GB_LOG_CRIT, "Exiting ...");
 
       if (WEXITSTATUS(wstatus) == EXIT_SUCCESS) {
         exit(EXIT_SUCCESS);

--- a/rpc/block_svc_routines.c
+++ b/rpc/block_svc_routines.c
@@ -3455,7 +3455,7 @@ blockModifySizeCliFormatResponse(blockModifySizeCli *blk, struct blockModifySize
 
   hr_size = glusterBlockFormatSize("mgmt", mobj->size);
   if (!hr_size) {
-    GB_ASPRINTF (&errMsg, "%s", "failed in glusterBlockFormatSize");
+    GB_ASPRINTF (&errMsg, "failed in glusterBlockFormatSize");
     blockFormatErrorResponse(MODIFY_SIZE_SRV, blk->json_resp, ENOMEM,
                              errMsg, reply);
     GB_FREE(errMsg);
@@ -4781,7 +4781,7 @@ block_version_1_svc_st(void *data, struct svc_req *rqstp)
   int i;
 
 
-  LOG("mgmt", GB_LOG_DEBUG, "%s", "version check request");
+  LOG("mgmt", GB_LOG_DEBUG, "version check request");
 
   if (GB_ALLOC(reply) < 0) {
     return NULL;
@@ -5160,7 +5160,7 @@ blockInfoCliFormatResponse(blockInfoCli *blk, int errCode,
   if (!hr_size) {
     hr_size = glusterBlockFormatSize("mgmt", info->size);
     if (!hr_size) {
-      GB_ASPRINTF (&errMsg, "%s", "failed in glusterBlockFormatSize");
+      GB_ASPRINTF (&errMsg, "failed in glusterBlockFormatSize");
       blockFormatErrorResponse(INFO_SRV, blk->json_resp, ENOMEM,
                                errMsg, reply);
       GB_FREE(errMsg);

--- a/utils/common.c
+++ b/utils/common.c
@@ -57,7 +57,7 @@ glusterBlockParseSize(const char *dom, char *value)
 
   sizef = strtod(value, &postfix);
   if (sizef <= 0) {
-    LOG(dom, GB_LOG_ERROR, "%s", "size cannot be negative number or zero");
+    LOG(dom, GB_LOG_ERROR, "size cannot be negative number or zero");
     return -1;
   }
 
@@ -94,14 +94,14 @@ glusterBlockParseSize(const char *dom, char *value)
   case 'b':
   case '\0':
     if (sizef < GB_DEFAULT_SECTOR_SIZE) {
-        MSG(stderr, "minimum acceptable block size is %d bytes\n", GB_DEFAULT_SECTOR_SIZE);
+        MSG(stderr, "minimum acceptable block size is %d bytes", GB_DEFAULT_SECTOR_SIZE);
         LOG(dom, GB_LOG_ERROR, "minimum acceptable block size is %d bytes",
             GB_DEFAULT_SECTOR_SIZE);
         return -1;
     }
 
     if (sizef % GB_DEFAULT_SECTOR_SIZE) {
-      MSG(stdout, "The size %ld will align to sector size %d bytes\n",
+      MSG(stdout, "The size %ld will align to sector size %d bytes",
           sizef, GB_DEFAULT_SECTOR_SIZE);
       LOG(dom, GB_LOG_ERROR,
           "The target device size %ld will align to the sector size %d",
@@ -124,7 +124,7 @@ glusterBlockParseSize(const char *dom, char *value)
   return sizef;
 
 fail:
-  LOG(dom, GB_LOG_ERROR, "%s",
+  LOG(dom, GB_LOG_ERROR,
       "Unknown size unit. "
       "You may use b/B, k/K(iB), m/M(iB), g/G(iB), and t/T(iB) suffixes for "
       "bytes, kibibytes, mebibytes, gibibytes, and tebibytes.");
@@ -148,7 +148,7 @@ glusterBlockFormatSize(const char *dom, size_t bytes)
   }
 
   if (GB_ASPRINTF(&buf, "%.1f %s", (float)bytes + (float)rem / 1024.0, units[i]) < 0) {
-    LOG(dom, GB_LOG_ERROR, "%s", "glusterBlockFormatSize() failed");
+    LOG(dom, GB_LOG_ERROR, "glusterBlockFormatSize() failed");
     buf = NULL;
   }
 

--- a/utils/lru.c
+++ b/utils/lru.c
@@ -26,7 +26,7 @@ int
 glusterBlockSetLruCount(const size_t lruCount)
 {
   if (!lruCount || (lruCount > LRU_COUNT_MAX)) {
-    MSG(stderr, "glfsLruCount should be [0 < COUNT < %d]\n",
+    MSG(stderr, "glfsLruCount should be [0 < COUNT < %d]",
         LRU_COUNT_MAX);
     LOG("mgmt", GB_LOG_ERROR,
         "glfsLruCount should be [0 < COUNT < %d]",

--- a/utils/utils.c
+++ b/utils/utils.c
@@ -38,7 +38,7 @@ int
 glusterBlockSetLogLevel(unsigned int logLevel)
 {
   if (logLevel >= GB_LOG_MAX) {
-    MSG(stderr, "unknown LOG-LEVEL: '%d'\n", logLevel);
+    MSG(stderr, "unknown LOG-LEVEL: '%d'", logLevel);
     return -1;
   }
   LOCK(gbConf.lock);
@@ -62,7 +62,7 @@ int
 glusterBlockSetCliTimeout(size_t timeout)
 {
   if (timeout < 0) {
-    MSG(stderr, "unknown GB_CLI_TIMEOUT: '%zu'\n", timeout);
+    MSG(stderr, "unknown GB_CLI_TIMEOUT: '%zu'", timeout);
     return -1;
   }
   LOCK(gbConf.lock);
@@ -289,7 +289,7 @@ initLogging(void)
   }
 
   if (strlen(logDir) > PATH_MAX - GB_MAX_LOGFILENAME) {
-    fprintf(stderr, "strlen of logDir Path > PATH_MAX: %s\n", logDir);
+    fprintf(stderr, "strlen of logDir Path > PATH_MAX: %s", logDir);
     return EXIT_FAILURE;
   }
 

--- a/utils/utils.h
+++ b/utils/utils.h
@@ -124,9 +124,19 @@
 
 # define  MSG(fd, fmt, ...)                                          \
           do {                                                       \
+            int len;                                                 \
+            char *buf;                                               \
             if (fd <= 0)       /* including STDIN_FILENO 0 */        \
               fd = stderr;                                           \
-            fprintf(fd, fmt, __VA_ARGS__);                           \
+            len = GB_ASPRINTF(&buf, fmt, ##__VA_ARGS__);             \
+            if (len != -1) {                                         \
+              if (buf[len - 1] != '\n')                              \
+                buf[len - 1] = '\n';                                 \
+              fprintf(fd, "%s", buf);                                \
+              free(buf);                                             \
+            } else {                                                 \
+              fprintf(fd, fmt "\n", ##__VA_ARGS__);                  \
+            }                                                        \
           } while (0)
 
 
@@ -172,7 +182,7 @@ extern struct gbConf gbConf;
               logTimeNow(timestamp, GB_TIME_STRING_BUFLEN);            \
               fprintf(fd, "[%s] %s: " fmt " [at %s+%d :<%s>]\n",       \
                       timestamp, LogLevelLookup[level],                \
-                      __VA_ARGS__, __FILE__, __LINE__, __FUNCTION__);  \
+                      ##__VA_ARGS__, __FILE__, __LINE__, __FUNCTION__);\
               if (fd != stderr)                                        \
                 fclose(fd);                                            \
             }                                                          \
@@ -225,7 +235,7 @@ extern struct gbConf gbConf;
               ret = -1;                                                 \
               goto label;                                               \
             }                                                           \
-            if (GB_ASPRINTF(&write, __VA_ARGS__) < 0) {                 \
+            if (GB_ASPRINTF(&write, ##__VA_ARGS__) < 0) {               \
               ret = -1;                                                 \
             }                                                           \
             if (!ret) {                                                 \
@@ -309,7 +319,7 @@ extern struct gbConf gbConf;
            char vol_blk[1024];                                         \
            snprintf(vol_blk, 1024, "%s/%s", vol?vol:"",                \
                     blk->block_name);                                  \
-           if (GB_ASPRINTF(&tmp, __VA_ARGS__) == -1)                   \
+           if (GB_ASPRINTF(&tmp, ##__VA_ARGS__) == -1)                 \
              goto label;                                               \
            if (!strstr(out, tmp)) {                                    \
              GB_FREE(tmp);                                             \


### PR DESCRIPTION
### What does this PR achieve? Why do we need it?
Allow call the logger helpers without any variable argument

If there is no any variable argument in the logger helpers, it
will hit the following compile errors:

../utils/utils.h:175:34: error: expected expression before ‘,’ token
                       __VA_ARGS__, __FILE__, __LINE__, __FUNCTION__);  \
                                  ^
gluster-blockd.c:268:5: note: in expansion of macro ‘LOG’
     LOG ("mgmt", GB_LOG_ERROR, "Test................");
     ^

More detail please see the GNU doc:
https://gcc.gnu.org/onlinedocs/cpp/Variadic-Macros.html

### Does this PR fix issues?
No.

### Notes for the reviewer
