### PR TITLE
configure: fix warning about '--enable-tirpc'

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -43,8 +43,8 @@ AC_ARG_WITH(sysconfigdir,
             [sysconfigdir='/etc/sysconfig'])
 AC_SUBST(sysconfigdir)
 
-AC_ARG_ENABLE([libtirpc],
-              AC_HELP_STRING([--enable-libtirpc],
+AC_ARG_ENABLE([tirpc],
+              AC_HELP_STRING([--enable-tirpc],
                              [enable use of tirpc [default: yes]]))
 
 AM_INIT_AUTOMAKE([-Wall -Werror foreign nostdinc])


### PR DESCRIPTION

<!--
Thanks for sending a pull request! Your contribution is very much appreciated.

Here are some tips for you:

1. Split the changes up into minimal and atomic commits.
2. Please write a good description about your changes in commit message.
3. Write a meaningful PR text. Remember: one PR per feature or bugfix. If in doubt, split your patchset into multiple PRs.
-->

### What does this PR achieve? Why do we need it?

Fix Warning logs:

[root@Fedora-Server gluster-block]# ./configure --enable-tirpc=no
configure: WARNING: unrecognized options: --enable-tirpc
checking whether make supports nested variables... yes
[...]
configure: WARNING: unrecognized options: --enable-tirpc

\------------------ Summary ------------------
 gluster-block version 0.3
  Prefix.........: /usr/local
  C Compiler.....: gcc -g -O2
  Linker.........: /usr/bin/ld -m elf_x86_64
  Using Tirpc....: no
\---------------------------------------------



### Does this PR fix issues?

<!-- This is optional, 'Fixes: #<issue-number>' lines will close the issue if the PR is merged.  -->

Fixes: #212
Signed-off-by: Prasanna Kumar Kalever <prasanna.kalever@redhat.com>


### Notes for the reviewer


