### PR TITLE
build: fix compile time warning

### DIFF
--- a/utils/utils.c
+++ b/utils/utils.c
@@ -9,6 +9,8 @@
 */
 
 
+# define   _GNU_SOURCE         /* See feature_test_macros(7) */
+# include  <stdio.h>
 # include  <dirent.h>
 # include  <sys/stat.h>
 


### PR DESCRIPTION

<!--
Thanks for sending a pull request! Your contribution is very much appreciated.

Here are some tips for you:

1. Split the changes up into minimal and atomic commits.
2. Please write a good description about your changes in commit message.
3. Write a meaningful PR text. Remember: one PR per feature or bugfix. If in doubt, split your patchset into multiple PRs.
-->

### What does this PR achieve? Why do we need it?

Warning seen with make:
\--------------------------------
```
$ make
[...]
In file included from utils.c:15:
utils.c: In function ‘glusterBlockSetLogLevel’:
utils.h:113:27: warning: implicit declaration of function ‘asprintf’; did you mean ‘vsprintf’? [-Wimplicit-function-de
claration]
                 int __ret=asprintf(ptr, ##fmt);__ret;})
                           ^~~~~~~~
utils.h:131:19: note: in expansion of macro ‘GB_ASPRINTF’
             len = GB_ASPRINTF(&buf, fmt, ##__VA_ARGS__);             \
                   ^~~~~~~~~~~
utils.c:41:5: note: in expansion of macro ‘MSG’
     MSG(stderr, "unknown LOG-LEVEL: '%d'", logLevel);
     ^~~
  CC       libgb_la-lru.lo
[...]

```

### Does this PR fix issues?

Compile time warnings.

Signed-off-by: Prasanna Kumar Kalever <prasanna.kalever@redhat.com>


<!-- This is optional, 'Fixes: #<issue-number>' lines will close the issue if the PR is merged.  -->
