### PR TITLE
gluster-block: fix block delete failure

### DIFF
--- a/gluster-block.spec.in
+++ b/gluster-block.spec.in
@@ -32,8 +32,9 @@ BuildRequires:    rpcgen
 BuildRequires:    systemd
 %endif
 
-Requires:         tcmu-runner >= 1.0.4
-Requires:         targetcli >= 2.1.fb43
+Requires:         tcmu-runner >= 1.1.3
+Requires:         targetcli >= 2.1.fb49
+Requires:         python-rtslib >= 2.1.fb69
 Requires:         rpcbind
 
 %description
@@ -94,6 +95,9 @@ rm -rf ${RPM_BUILD_ROOT}
      %attr(0644,-,-) %{_sharedstatedir}/gluster-block/gluster-block-caps.info
 
 %changelog
+* Mon Apr 22 2019 Prasanna Kumar Kalever <prasanna.kalever@redhat.com>
+- update targetcli and tcmu-runner dependency version
+
 * Fri Aug 10 2018 Niels de Vos <ndevos@redhat.com>
 - use the modern libtirpc package, will be removed from glibc
 - new Fedora releases require rpcgen (unbundled from glibc)

--- a/version.h
+++ b/version.h
@@ -23,10 +23,10 @@
 
 /* Other dependencies versions */
 # define  GB_MIN_TCMURUNNER_VERSION            "1.1.3"
-# define  GB_MIN_TARGETCLI_VERSION             "2.1.fb46"
+# define  GB_MIN_TARGETCLI_VERSION             "2.1.fb49"
 
 # define  GB_MIN_TCMURUNNER_VERSION_CODE       65795
-# define  GB_MIN_TARGETCLI_VERSION_CODE        131374
+# define  GB_MIN_TARGETCLI_VERSION_CODE        131377
 
 
 # endif /* _VERSION_H */


### PR DESCRIPTION
<!--
Thanks for sending a pull request! Your contribution is very much appreciated.

Here are some tips for you:

1. Split the changes up into minimal and atomic commits.
2. Please write a good description about your changes in commit message.
3. Write a meaningful PR text. Remember: one PR per feature or bugfix. If in doubt, split your patchset into multiple PRs.
-->

### What does this PR achieve? Why do we need it?

Problem:
-------

TEST : gluster-block delete hosting-volume/block-volume
FAILED ON:   192.168.124.147
SUCCESSFUL ON: None
RESULT: FAIL
line 98 : NOT OK

Solution:
--------

This is because, the below command was failing,

$ targetcli /backstores/user:glfs delete name=block-volume save=True
Unexpected keyword parameter 'save'.

Since, gluster-block now use per storage object save feature of targetcli,

need, below commit from targetcli, to fix delete failures:
```

commit bca03ea400a691e4218113b6d10adb61ce0cd511 (refs/remotes/origin/save_del)
  Author: Prasanna Kumar Kalever <prasanna.kalever@redhat.com>
  Date:   Fri Jun 1 16:15:22 2018 +0530

      saveconfig: way for block-level save with delete comman


```
which is part of targetcli-2.1.fb49, hence turning the dependency check to
latest released and packaged version.

Signed-off-by: Prasanna Kumar Kalever <prasanna.kalever@redhat.com>

