### PR TITLE
gluster-block: fix create failure with ring-buffer option

### DIFF
--- a/rpc/block_svc_routines.c
+++ b/rpc/block_svc_routines.c
@@ -4515,7 +4515,7 @@ block_create_v2_1_svc_st(blockCreate2 *blk, struct svc_req *rqstp)
 
 
   if (blk->rb_size) {
-    GB_ASPRINTF(&rbsize, ",%s=%d", GB_RING_BUFFER_STR, blk->rb_size);
+    GB_ASPRINTF(&rbsize, " control='%s=%d'", GB_RING_BUFFER_STR, blk->rb_size);
   }
 
   convertTypeCreate2ToCreate(blk, &blk_v1);


### PR DESCRIPTION

<!--
Thanks for sending a pull request! Your contribution is very much appreciated.

Here are some tips for you:

1. Split the changes up into minimal and atomic commits.
2. Please write a good description about your changes in commit message.
3. Write a meaningful PR text. Remember: one PR per feature or bugfix. If in doubt, split your patchset into multiple PRs.
-->

### What does this PR achieve? Why do we need it?

Problem:
-------

TEST : gluster-block create hosting-volume/block-volume ring-buffer 32 192.168.124.184 1MiB
failed to configure on 192.168.124.184 configure failed
RESULT:FAIL
line 125 : NOT OK

Solution:
--------
We found out that the cfgstring containing commas is parsed correctly by
configshell and passed to the kernel without problems.

we used the following cfgstring:
'dev_config=glfs/hosting-volume@192.168.124.184/block-store/ed9ffb77-63b7-4a91-b2cd-f176eb5be847,max_data_area_mb=32'

But then we see that the ",key1=val1" part has been truncated by the kernel

Read More: https://bugzilla.redhat.com/show_bug.cgi?id=1623925#c24

Later, there was a new way to pass such options via targetcli , with:

```
commit ffafd9680228ec5c39cc721f0db50b7babc2c91d (refs/remotes/origin/control_str, refs/pull/origin/109)
Author: Prasanna Kumar Kalever <prasanna.kalever@redhat.com>
Date:   Fri Apr 6 13:19:54 2018 +0530

    create: add a way to set control string

    this patch enable users to supply control option, a string containing comma
    separated control=value kind tuples, that are passed to the kernel control file.

    Example:
    $ targetcli /backstores/user:glfs create blockX1 1073741824 \
        test@192.168.124.227/block-store/e59309bb-d591-4121-a891-e98ff3416446 \
        control="max_data_area_mb=32,hw_max_sectors=256"

    Signed-off-by: Prasanna Kumar Kalever <prasanna.kalever@redhat.com>
```

This patch, adjust to use control="key1=value1" way of passing control commands

Signed-off-by: Prasanna Kumar Kalever <prasanna.kalever@redhat.com>


