### PR TITLE
Spec: misc fix

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -4,6 +4,8 @@ SUBDIRS = rpc utils cli daemon systemd docs extras tests
 
 DISTCLEANFILES = Makefile.in gluster-block.spec autom4te.cache
 
+noinst_HEADERS = version.h config.h
+
 CLEANFILES = *~ gluster-block.spec
 
 EXTRA_DIST = autogen.sh README.md COPYING-GPLV2 COPYING-LGPLV3 \

--- a/cli/gluster-block.c
+++ b/cli/gluster-block.c
@@ -63,7 +63,6 @@ gbConfig *
 glusterBlockCLILoadConfig(void)
 {
   gbConfig *cfg = NULL;
-  int ret;
 
   if (GB_ALLOC(cfg) < 0) {
     LOG("cli", GB_LOG_ERROR,
@@ -460,8 +459,8 @@ static int
 glusterBlockModify(int argcount, char **options, int json)
 {
   size_t optind = 1;
-  blockModifyCli mobj = {0, };
-  blockModifySizeCli msobj = {0, };
+  blockModifyCli mobj = {{0}, };
+  blockModifySizeCli msobj = {{0}, };
   char volume[255] = {0};
   char block[255] = {0};
   ssize_t sparse_ret;
@@ -564,7 +563,7 @@ glusterBlockCreate(int argcount, char **options, int json)
   size_t optind = 1;
   int ret = -1;
   ssize_t sparse_ret;
-  blockCreateCli cobj = {0, };
+  blockCreateCli cobj = {{0}, };
   bool TAKE_SIZE=true;
   bool PREALLOC_OPT=false;
 
@@ -722,7 +721,7 @@ glusterBlockCreate(int argcount, char **options, int json)
 static int
 glusterBlockList(int argcount, char **options, int json)
 {
-  blockListCli cobj = {0};
+  blockListCli cobj = {{0},};
   int ret = -1;
 
 
@@ -744,7 +743,7 @@ glusterBlockList(int argcount, char **options, int json)
 static int
 glusterBlockDelete(int argcount, char **options, int json)
 {
-  blockDeleteCli dobj = {0};
+  blockDeleteCli dobj = {{0},};
   size_t optind = 1;
   int ret = -1;
 
@@ -811,7 +810,7 @@ glusterBlockDelete(int argcount, char **options, int json)
 static int
 glusterBlockInfo(int argcount, char **options, int json)
 {
-  blockInfoCli cobj = {0};
+  blockInfoCli cobj = {{0},};
   int ret = -1;
 
 
@@ -840,7 +839,7 @@ glusterBlockInfo(int argcount, char **options, int json)
 static int
 glusterBlockReplace(int argcount, char **options, int json)
 {
-  blockReplaceCli robj = {0};
+  blockReplaceCli robj = {{0},};
   int ret = -1;
   int optind = 1;
 
@@ -904,7 +903,7 @@ glusterBlockReplace(int argcount, char **options, int json)
 static int
 glusterBlockGenConfig(int argcount, char **options, int json)
 {
-  blockGenConfigCli robj = {0};
+  blockGenConfigCli robj = {{0},};
   int ret = -1;
   int optind = 1;
 

--- a/daemon/gluster-blockd.c
+++ b/daemon/gluster-blockd.c
@@ -77,7 +77,7 @@ void
 onSigServerHandler(int signum)
 {
   LOG("mgmt", GB_LOG_DEBUG,
-      "server process with (pid: %lu) received (signal: %s)",
+      "server process with (pid: %u) received (signal: %s)",
       getpid(), strsignal(signum));
 
   svc_exit();
@@ -90,7 +90,7 @@ void
 onSigCliHandler(int signum)
 {
   LOG("mgmt", GB_LOG_DEBUG,
-      "cli process with (pid: %lu) received (signal: %s)",
+      "cli process with (pid: %u) received (signal: %s)",
       getpid(), strsignal(signum));
 
   kill(ctx.chpid, signum);  /* Pass the signal to server process */
@@ -352,9 +352,9 @@ glusterBlockDParseArgs(int count, char **options)
 static void
 gbMinKernelVersionCheck(void)
 {
-  struct utsname verStr = {'\0', };
+  struct utsname verStr = {{0},};
   char *distro = NULL;
-  size_t vNum[VERNUM_BUFLEN] = {0, };
+  size_t vNum[VERNUM_BUFLEN] = {0,};
   int i = 0;
   char *tptr;
 
@@ -647,7 +647,7 @@ main (int argc, char **argv)
     LOG("mgmt", GB_LOG_ERROR, "failed forking: (%s)", strerror(errno));
     goto out;
   } else if (ctx.chpid == 0) {
-    LOG("mgmt", GB_LOG_INFO, "server process pid: (%lu)", getpid());
+    LOG("mgmt", GB_LOG_INFO, "server process pid: (%u)", getpid());
 
     /* Handle signals */
     signal(SIGINT,  onSigServerHandler);
@@ -657,7 +657,7 @@ main (int argc, char **argv)
 
     exit (EXIT_FAILURE); /* server process svc_run exits */
   } else {
-    LOG("mgmt", GB_LOG_INFO, "cli process pid: (%lu)", getpid());
+    LOG("mgmt", GB_LOG_INFO, "cli process pid: (%u)", getpid());
 
     /* Handle signals */
     signal(SIGINT,  onSigCliHandler);

--- a/extras/Makefile.am
+++ b/extras/Makefile.am
@@ -1,4 +1,5 @@
-EXTRA_DIST = replace-node.sh wait-for-bricks.sh upgrade_activities.sh
+EXTRA_DIST = replace-node.sh wait-for-bricks.sh upgrade_activities.sh            \
+			 gluster-blockd.logrotate
 
 DISTCLEANFILES = Makefile.in
 
@@ -11,11 +12,11 @@ install-data-local:
 	$(INSTALL_DATA) -m 755 $(top_srcdir)/extras/upgrade_activities.sh            \
 		$(DESTDIR)$(GLUSTER_BLOCKD_LIBEXECDIR)/upgrade_activities.sh;            \
 	$(MKDIR_P) $(DESTDIR)$(GLUSTER_BLOCKD_LOGROTATEDIR);                         \
-	$(INSTALL_DATA) -m 644 gluster-blockd.logrotate                               \
+	$(INSTALL_DATA) gluster-blockd.logrotate                               \
 		$(DESTDIR)$(GLUSTER_BLOCKD_LOGROTATEDIR)/gluster-blockd;
 
 uninstall-local:
 	rm -f $(DESTDIR)$(GLUSTER_BLOCKD_LIBEXECDIR)/wait-for-bricks.sh              \
 		$(DESTDIR)$(GLUSTER_BLOCKD_LIBEXECDIR)/upgrade_activities.sh             \
 		$(DESTDIR)$(GLUSTER_BLOCKD_WORKDIR)/gb_upgrade.status                    \
-		$(DESTDIR)$(GLUSTER_BLOCKD_LOGROTATEDIR)/gluster-block;
+		$(DESTDIR)$(GLUSTER_BLOCKD_LOGROTATEDIR)/gluster-blockd;

--- a/gluster-block.spec.in
+++ b/gluster-block.spec.in
@@ -8,6 +8,10 @@
 %global _with_initd true
 %endif
 
+%if ( 0%{?rhel} && 0%{?rhel} <= 7 ) || ( 0%{?centos_version} && 0%{?centos_version} <= 7 ) 
+%global _disable_tirpc --enable-tirpc=no
+%endif
+
 
 ##-----------------------------------------------------------------------------
 ## All package definitions should be placed here
@@ -22,9 +26,9 @@ Source0:          @PACKAGE_NAME@-@PACKAGE_VERSION@.tar.gz
 
 BuildRequires:    pkgconfig(glusterfs-api)
 BuildRequires:    pkgconfig(json-c)
-BuildRequires:    pkgconfig(libtirpc)
 BuildRequires:    help2man >= 1.36
-%if ( 0%{?fedora} && 0%{?fedora} >= 28 )
+%if ( 0%{?_disable_tirpc:0} ) 
+BuildRequires:    pkgconfig(libtirpc)
 BuildRequires:    rpcgen
 %endif
 %if ( 0%{?_with_systemd:1} )
@@ -45,7 +49,7 @@ storage creation and maintenance as simple as possible.
 %setup -q
 
 %build
-%configure
+%configure %{?_disable_tirpc}
 %make_build
 
 %install

--- a/gluster-block.spec.in
+++ b/gluster-block.spec.in
@@ -101,11 +101,11 @@ rm -rf ${RPM_BUILD_ROOT}
 * Mon Apr 22 2019 Prasanna Kumar Kalever <prasanna.kalever@redhat.com>
 - update targetcli and tcmu-runner dependency version
 
-* Fri Aug 10 2018 Niels de Vos <ndevos@redhat.com>
+* Mon Apr 15 2019 Niels de Vos <ndevos@redhat.com>
 - use the modern libtirpc package, will be removed from glibc
 - new Fedora releases require rpcgen (unbundled from glibc)
 
-* Sun Apr 3 2019 Xiubo Li <xiubli@redhat.com>
+* Wed Apr 03 2019 Xiubo Li <xiubli@redhat.com>
 - Add logrotate support
 
 * Sun Oct 14 2018 Prasanna Kumar Kalever <prasanna.kalever@redhat.com>

--- a/rpc/block_svc_routines.c
+++ b/rpc/block_svc_routines.c
@@ -215,7 +215,7 @@ mapJsonFlagToJsonCstring(int jsonflag)
 
 void
 blockFormatErrorResponse(operations op, int json_resp, int errCode,
-                         char *errMsg, struct blockResponse *reply)
+                         char *errMsg, blockResponse *reply)
 {
   json_object *json_obj = NULL;
 
@@ -516,8 +516,8 @@ glusterBlockCallRPC_1(char *host, void *cobj,
   blockResponse reply = {0,};
   struct addrinfo *res = NULL;
   gbCapResp *obj = NULL;
-  struct blockCreate cblk_v1 = {0,};
-  struct blockCreate2 *cblk_v2 = NULL;
+  blockCreate cblk_v1 = {{0},};
+  blockCreate2 *cblk_v2 = NULL;
 
 
   *rpc_sent = FALSE;
@@ -894,7 +894,7 @@ static int
 glusterBlockCapabilityRemoteAsync(blockServerDef *servers, bool *minCaps,
                                   bool *resultCaps, char **errMsg)
 {
-  static blockRemoteObj *args = NULL;
+  blockRemoteObj *args = NULL;
   pthread_t  *tid = NULL;
   int ret = -1;
   size_t i;
@@ -1004,7 +1004,7 @@ glusterBlockCreateRemoteAsync(blockServerDefPtr list,
                             blockRemoteCreateResp **savereply)
 {
   pthread_t  *tid = NULL;
-  static blockRemoteObj *args = NULL;
+  blockRemoteObj *args = NULL;
   int ret = -1;
   size_t i;
 
@@ -2197,7 +2197,7 @@ glusterBlockReplaceNodeRemoteAsync(struct glfs *glfs, blockReplaceCli *blk,
 void
 blockReplaceNodeCliFormatResponse(blockReplaceCli *blk, int errCode, char *errMsg,
                                   blockRemoteReplaceResp *savereply,
-                                  struct blockResponse *reply)
+                                  blockResponse *reply)
 {
   json_object *json_obj = NULL;
   char *tmp = NULL;
@@ -2530,7 +2530,7 @@ block_replace_cli_1_svc_st(blockReplaceCli *blk, struct svc_req *rqstp)
  out:
   GB_METAUNLOCK(lkfd, blk->volume, errCode, errMsg);
   blockReplaceNodeCliFormatResponse(blk, errCode, errMsg, savereply, reply);
-  LOG("cmdlog", errCode?GB_LOG_ERROR:GB_LOG_INFO, "%s", reply->out);
+  LOG("cmdlog", ((!!errCode) ? GB_LOG_ERROR : GB_LOG_INFO), "%s", reply->out);
   blockServerDefFree(list);
   blockRemoteReplaceRespFree(savereply);
   blockFreeMetaInfo(info);
@@ -2944,7 +2944,7 @@ glusterBlockCleanUp(struct glfs *glfs, char *blockname,
                     bool deleteall, bool forcedel, bool unlink, blockRemoteDeleteResp *drobj)
 {
   int ret = -1;
-  static blockDelete dobj;
+  blockDelete dobj;
   size_t count = 0;
   MetaInfo *info = NULL;
   int asyncret = 0;
@@ -3116,10 +3116,10 @@ glusterBlockAuditRequest(struct glfs *glfs,
 
 
 static void
-blockModifyCliFormatResponse (blockModifyCli *blk, struct blockModify *mobj,
+blockModifyCliFormatResponse (blockModifyCli *blk, blockModify *mobj,
                               int errCode, char *errMsg,
                               blockRemoteModifyResp *savereply,
-                              MetaInfo *info, struct blockResponse *reply,
+                              MetaInfo *info, blockResponse *reply,
                               bool rollback)
 {
   json_object *json_obj = NULL;
@@ -3234,9 +3234,9 @@ blockResponse *
 block_modify_cli_1_svc_st(blockModifyCli *blk, struct svc_req *rqstp)
 {
   int ret = -1;
-  static blockModify mobj = {0};
-  static blockRemoteModifyResp *savereply = NULL;
-  static blockResponse *reply = NULL;
+  blockModify mobj = {{0}};
+  blockRemoteModifyResp *savereply = NULL;
+  blockResponse *reply = NULL;
   struct glfs *glfs;
   struct glfs_fd *lkfd = NULL;
   MetaInfo *info = NULL;
@@ -3410,7 +3410,7 @@ block_modify_cli_1_svc_st(blockModifyCli *blk, struct svc_req *rqstp)
  initfail:
   blockModifyCliFormatResponse (blk, &mobj, asyncret?asyncret:errCode,
                                 errMsg, savereply, info, reply, rollback);
-  LOG("cmdlog", errCode?GB_LOG_ERROR:GB_LOG_INFO, "%s", reply->out);
+  LOG("cmdlog", ((!!errCode) ? GB_LOG_ERROR : GB_LOG_INFO), "%s", reply->out);
   blockFreeMetaInfo(info);
 
   if (savereply) {
@@ -3427,10 +3427,10 @@ block_modify_cli_1_svc_st(blockModifyCli *blk, struct svc_req *rqstp)
 
 
 static void
-blockModifySizeCliFormatResponse(blockModifySizeCli *blk, struct blockModifySize *mobj,
+blockModifySizeCliFormatResponse(blockModifySizeCli *blk, blockModifySize *mobj,
                                  int errCode, char *errMsg,
                                  blockRemoteResp *savereply,
-                                 MetaInfo *info, struct blockResponse *reply)
+                                 MetaInfo *info, blockResponse *reply)
 {
   json_object *json_obj = NULL;
   char        *tmp = NULL;
@@ -3536,9 +3536,9 @@ blockResponse *
 block_modify_size_cli_1_svc_st(blockModifySizeCli *blk, struct svc_req *rqstp)
 {
   int ret = -1;
-  static blockModifySize mobj = {0};
-  static blockRemoteResp *savereply = NULL;
-  static blockResponse *reply = NULL;
+  blockModifySize mobj = {{0},};
+  blockRemoteResp *savereply = NULL;
+  blockResponse *reply = NULL;
   struct glfs *glfs;
   struct glfs_fd *lkfd = NULL;
   MetaInfo *info = NULL;
@@ -3683,7 +3683,7 @@ block_modify_size_cli_1_svc_st(blockModifySizeCli *blk, struct svc_req *rqstp)
  initfail:
   blockModifySizeCliFormatResponse(blk, &mobj, asyncret?asyncret:errCode,
                                    errMsg, savereply, info, reply);
-  LOG("cmdlog", errCode?GB_LOG_ERROR:GB_LOG_INFO, "%s", reply->out);
+  LOG("cmdlog", ((!!errCode) ? GB_LOG_ERROR : GB_LOG_INFO), "%s", reply->out);
   blockFreeMetaInfo(info);
 
   blockRemoteRespFree(savereply);
@@ -3695,9 +3695,9 @@ block_modify_size_cli_1_svc_st(blockModifySizeCli *blk, struct svc_req *rqstp)
 
 void
 blockCreateCliFormatResponse(struct glfs *glfs, blockCreateCli *blk,
-                             struct blockCreate2 *cobj, int errCode,
+                             blockCreate2 *cobj, int errCode,
                              char *errMsg, blockRemoteCreateResp *savereply,
-                             struct blockResponse *reply)
+                             blockResponse *reply)
 {
   MetaInfo *info = NULL;
   json_object *json_obj = NULL;
@@ -3860,12 +3860,12 @@ block_create_cli_1_svc_st(blockCreateCli *blk, struct svc_req *rqstp)
   blockRemoteCreateResp *savereply = NULL;
   char gbid[UUID_BUF_SIZE];
   char passwd[UUID_BUF_SIZE];
-  struct blockResponse *reply;
+  blockResponse *reply;
   struct glfs *glfs = NULL;
   struct glfs_fd *lkfd = NULL;
   blockServerDefPtr list = NULL;
   char *errMsg = NULL;
-  struct blockCreate2  cobj = {0, };
+  blockCreate2 cobj = {{0},};
   bool *resultCaps = NULL;
 
 
@@ -4027,7 +4027,7 @@ block_create_cli_1_svc_st(blockCreateCli *blk, struct svc_req *rqstp)
 
  optfail:
   blockCreateCliFormatResponse(glfs, blk, &cobj, errCode, errMsg, savereply, reply);
-  LOG("cmdlog", errCode?GB_LOG_ERROR:GB_LOG_INFO, "%s", reply->out);
+  LOG("cmdlog", ((!!errCode) ? GB_LOG_ERROR : GB_LOG_INFO), "%s", reply->out);
   GB_FREE(errMsg);
   blockServerDefFree(list);
   blockCreateParsedRespFree(savereply);
@@ -4509,7 +4509,7 @@ blockResponse *
 block_create_v2_1_svc_st(blockCreate2 *blk, struct svc_req *rqstp)
 {
   char *rbsize= NULL;
-  blockCreate blk_v1 = {0, };
+  blockCreate blk_v1 = {{0},};
   char *volServer = NULL;
   size_t len = blk->xdata.xdata_len;
 
@@ -4537,7 +4537,7 @@ err:
 void
 blockDeleteCliFormatResponse(blockDeleteCli *blk, int errCode, char *errMsg,
                              blockRemoteDeleteResp *savereply,
-                             struct blockResponse *reply)
+                             blockResponse *reply)
 {
   json_object *json_obj = NULL;
   char *tmp = NULL;
@@ -4601,7 +4601,7 @@ block_delete_cli_1_svc_st(blockDeleteCli *blk, struct svc_req *rqstp)
 {
   blockRemoteDeleteResp *savereply = NULL;
   MetaInfo *info = NULL;
-  static blockResponse *reply = NULL;
+  blockResponse *reply = NULL;
   struct glfs *glfs;
   struct glfs_fd *lkfd = NULL;
   char *errMsg = NULL;
@@ -4704,7 +4704,7 @@ block_delete_cli_1_svc_st(blockDeleteCli *blk, struct svc_req *rqstp)
 
 
   blockDeleteCliFormatResponse(blk, errCode, errMsg, savereply, reply);
-  LOG("cmdlog", errCode?GB_LOG_ERROR:GB_LOG_INFO, "%s", reply->out);
+  LOG("cmdlog", ((!!errCode) ? GB_LOG_ERROR : GB_LOG_INFO), "%s", reply->out);
 
   if (savereply) {
     GB_FREE(savereply->d_attempt);
@@ -5116,7 +5116,7 @@ block_list_cli_1_svc_st(blockListCli *blk, struct svc_req *rqstp)
 void
 blockInfoCliFormatResponse(blockInfoCli *blk, int errCode,
                            char *errMsg, MetaInfo *info,
-                           struct blockResponse *reply)
+                           blockResponse *reply)
 {
   json_object  *json_obj    = NULL;
   json_object  *json_array1 = NULL;

--- a/utils/utils.h
+++ b/utils/utils.h
@@ -162,15 +162,18 @@ extern struct gbConf gbConf;
           do {                                                         \
             FILE *fd;                                                  \
             char timestamp[GB_TIME_STRING_BUFLEN] = {0};               \
+            char *tmp;                                                 \
+            if (GB_STRDUP(tmp, str) < 0)                               \
+              fprintf(stderr, "No memory: %s\n", strerror(errno));     \
             LOCK(gbConf.lock);                                         \
             if (level <= gbConf.logLevel) {                            \
-              if ((str) == "mgmt")                                     \
+              if (!strcmp(tmp, "mgmt"))                                \
                 fd = fopen (gbConf.daemonLogFile, "a");                \
-              else if ((str) == "cli")                                 \
+              else if (!strcmp(tmp, "cli"))                            \
                 fd = fopen (gbConf.cliLogFile, "a");                   \
-              else if ((str) == "gfapi")                               \
+              else if (!strcmp(tmp, "gfapi"))                          \
                 fd = fopen (gbConf.gfapiLogFile, "a");                 \
-              else if ((str) == "cmdlog")                              \
+              else if (!strcmp(tmp, "cmdlog"))                         \
                 fd = fopen (gbConf.cmdhistoryLogFile, "a");            \
               else                                                     \
                 fd = stderr;                                           \
@@ -187,7 +190,8 @@ extern struct gbConf gbConf;
               if (fd != stderr)                                        \
                 fclose(fd);                                            \
             }                                                          \
-	    UNLOCK(gbConf.lock);                                     \
+            UNLOCK(gbConf.lock);                                       \
+            GB_FREE(tmp);                                              \
           } while (0)
 
 # define  GB_METALOCK_OR_GOTO(lkfd, volume, errCode, errMsg, label)  \


### PR DESCRIPTION
## spec: fix rpms build errors

Problems:
--------
$ make rpms
[...]
warning: bogus date in %changelog: Sun Apr 3 2019
error: %changelog not in descending chronological order
make: *** [rpms] Error 1

Solution:
--------
Correct the date in the changelog and update the date to when the
PR is merged.


## spec: disable tirpc when rhel <= 7 or fedora <= 27

Problem:
-------
In RHEL, when the version is <= 7 or fedora <= 27, the libtirpc
library is provided by glibc, so the make rpms will failed when
doing the configure.

Resolution:
---------
Disable the libtirpc check in RHEL <= 7 or fedora <= 27 as default.

