### PR TITLE
gbConf: Use shared memory instead of from the data segment

### DIFF
--- a/cli/gluster-block.c
+++ b/cli/gluster-block.c
@@ -1029,10 +1029,15 @@ main(int argc, char *argv[])
   int count = 1;
   int args = argc;
   int json = GB_JSON_NONE;
+  int ret;
 
 
   if (argc <= 1) {
     glusterBlockHelp();
+    goto fail;
+  }
+
+  if (initGbConfig()) {
     goto fail;
   }
 
@@ -1075,8 +1080,13 @@ main(int argc, char *argv[])
     break;
   }
 
-  return glusterBlockParseArgs(args - 1, &argv[count], opt, json);
+  ret = glusterBlockParseArgs(args - 1, &argv[count], opt, json);
+
+  finiGbConfig();
+
+  return ret;
 
  fail:
+  finiGbConfig();
   exit(EXIT_FAILURE);
 }

--- a/daemon/gluster-blockd.c
+++ b/daemon/gluster-blockd.c
@@ -337,7 +337,7 @@ glusterBlockDParseArgs(int count, char **options)
       break;
 
     case GB_DAEMON_NO_REMOTE_RPC:
-      gbConf.noRemoteRpc = true;
+      gbConf->noRemoteRpc = true;
       break;
 
     }
@@ -552,7 +552,7 @@ blockNodeSanityCheck(void)
   /* Check if dependencies meet minimum recommended versions */
   gbDependenciesVersionCheck();
 
-  if (GB_ASPRINTF(&global_opts, GB_TGCLI_GLOBALS, gbConf.configShellLogFile) == -1) {
+  if (GB_ASPRINTF(&global_opts, GB_TGCLI_GLOBALS, gbConf->configShellLogFile) == -1) {
     return ENOMEM;
   }
   /* Set targetcli globals */
@@ -588,8 +588,12 @@ main (int argc, char **argv)
   int wstatus;
 
 
-  if(initLogging()) {
+  if (initGbConfig()) {
     exit(EXIT_FAILURE);
+  }
+
+  if(initLogging()) {
+    goto out;
   }
 
   fetchGlfsVolServerFromEnv();
@@ -597,7 +601,7 @@ main (int argc, char **argv)
   gbCfg = glusterBlockSetupConfig();
   if (!gbCfg) {
     LOG("mgmt", GB_LOG_ERROR, "glusterBlockSetupConfig() failed");
-    exit(EXIT_FAILURE);
+    goto out;
   }
 
   if (glusterBlockDParseArgs(argc, argv)) {
@@ -619,7 +623,7 @@ main (int argc, char **argv)
     goto out;
   }
 
-  if (!gbConf.noRemoteRpc) {
+  if (!gbConf->noRemoteRpc) {
     if (blockNodeSanityCheck()) {
       goto out;
     }
@@ -638,7 +642,7 @@ main (int argc, char **argv)
   signal(SIGPIPE, SIG_IGN);
 
   pmap_unset(GLUSTER_BLOCK_CLI, GLUSTER_BLOCK_CLI_VERS);
-  if (!gbConf.noRemoteRpc) {
+  if (!gbConf->noRemoteRpc) {
     pmap_unset(GLUSTER_BLOCK, GLUSTER_BLOCK_VERS);
   }
 
@@ -686,6 +690,8 @@ main (int argc, char **argv)
   }
 
  out:
+  finiGbConfig();
+
   glusterBlockCleanGlobals();
   exit (EXIT_FAILURE);
   /* NOTREACHED */

--- a/rpc/block_svc_routines.c
+++ b/rpc/block_svc_routines.c
@@ -1937,8 +1937,8 @@ glusterBlockReplaceNodeRemoteAsync(struct glfs *glfs, blockReplaceCli *blk,
     goto out;
   }
 
-  cobj->xdata.xdata_len = strlen(gbConf.volServer);
-  cobj->xdata.xdata_val = (char *) gbConf.volServer;
+  cobj->xdata.xdata_len = strlen(gbConf->volServer);
+  cobj->xdata.xdata_val = (char *) gbConf->volServer;
   GB_STRCPYSTATIC(cobj->ipaddr, blk->new_node);
   GB_STRCPYSTATIC(cobj->volume, info->volume);
   GB_STRCPYSTATIC(cobj->gbid, info->gbid);
@@ -2709,10 +2709,10 @@ getSoObj(char *block, MetaInfo *info, blockGenConfigCli *blk)
   json_object_object_add(so_obj, "attributes", so_obj_attr);
   // }
 
-  if (!strcmp(gbConf.volServer, "localhost")) {
+  if (!strcmp(gbConf->volServer, "localhost")) {
     snprintf(cfgstr, 1024, "glfs/%s@%s/block-store/%s", info->volume, blk->addr, info->gbid);
   } else {
-    snprintf(cfgstr, 1024, "glfs/%s@%s/block-store/%s", info->volume, gbConf.volServer, info->gbid);
+    snprintf(cfgstr, 1024, "glfs/%s@%s/block-store/%s", info->volume, gbConf->volServer, info->gbid);
   }
   json_object_object_add(so_obj, "config", GB_JSON_OBJ_TO_STR(cfgstr[0]?cfgstr:NULL));
   if (info->rb_size) {
@@ -3981,8 +3981,8 @@ block_create_cli_1_svc_st(blockCreateCli *blk, struct svc_req *rqstp)
   cobj.rb_size = blk->rb_size;
   GB_STRCPYSTATIC(cobj.gbid, gbid);
   GB_STRDUP(cobj.block_hosts,  blk->block_hosts);
-  cobj.xdata.xdata_len = strlen(gbConf.volServer);
-  cobj.xdata.xdata_val = (char *) gbConf.volServer;
+  cobj.xdata.xdata_len = strlen(gbConf->volServer);
+  cobj.xdata.xdata_val = (char *) gbConf->volServer;
 
   if (blk->auth_mode) {
     uuid_generate(uuid);

--- a/rpc/glfs-operations.c
+++ b/rpc/glfs-operations.c
@@ -34,27 +34,27 @@ glusterBlockVolumeInit(char *volume, int *errCode, char **errMsg)
     GB_ASPRINTF (errMsg, "Not able to Initialize volume %s [%s]", volume,
                  strerror(*errCode));
     LOG("gfapi", GB_LOG_ERROR, "glfs_new(%s) from %s failed[%s]", volume,
-        gbConf.volServer, strerror(*errCode));
+        gbConf->volServer, strerror(*errCode));
     return NULL;
   }
 
-  ret = glfs_set_volfile_server(glfs, "tcp", gbConf.volServer, 24007);
+  ret = glfs_set_volfile_server(glfs, "tcp", gbConf->volServer, 24007);
   if (ret) {
     *errCode = errno;
     GB_ASPRINTF (errMsg, "Not able to add Volfile server for volume %s[%s]",
                  volume, strerror(*errCode));
     LOG("gfapi", GB_LOG_ERROR, "glfs_set_volfile_server(%s) of %s "
-        "failed[%s]", gbConf.volServer, volume, strerror(*errCode));
+        "failed[%s]", gbConf->volServer, volume, strerror(*errCode));
     goto out;
   }
 
-  ret = glfs_set_logging(glfs, gbConf.gfapiLogFile, GFAPI_LOG_LEVEL);
+  ret = glfs_set_logging(glfs, gbConf->gfapiLogFile, GFAPI_LOG_LEVEL);
   if (ret) {
     *errCode = errno;
     GB_ASPRINTF (errMsg, "Not able to add logging for volume %s[%s]", volume,
                  strerror(*errCode));
     LOG("gfapi", GB_LOG_ERROR, "glfs_set_logging(%s, %d) on %s failed[%s]",
-        gbConf.gfapiLogFile, GFAPI_LOG_LEVEL, volume, strerror(*errCode));
+        gbConf->gfapiLogFile, GFAPI_LOG_LEVEL, volume, strerror(*errCode));
     goto out;
   }
 

--- a/utils/lru.c
+++ b/utils/lru.c
@@ -64,9 +64,9 @@ glusterBlockSetLruCount(const size_t lruCount)
     return -1;
   }
 
-  LOCK(gbConf.lock);
-  gbConf.glfsLruCount = lruCount;
-  UNLOCK(gbConf.lock);
+  LOCK(gbConf->lock);
+  gbConf->glfsLruCount = lruCount;
+  UNLOCK(gbConf->lock);
 
   LOG("mgmt", GB_LOG_CRIT,
       "glfsLruCount now is %lu", lruCount);
@@ -103,13 +103,13 @@ appendNewEntry(const char *volname, glfs_t *fs)
   Entry *tmp;
 
 
-  LOCK(gbConf.lock);
-  if (lruCount == gbConf.glfsLruCount) {
+  LOCK(gbConf->lock);
+  if (lruCount == gbConf->glfsLruCount) {
     releaseColdEntry();
   }
 
   if (GB_ALLOC(tmp) < 0) {
-    UNLOCK(gbConf.lock);
+    UNLOCK(gbConf->lock);
     return -1;
   }
   GB_STRCPYSTATIC(tmp->volume, volname);
@@ -120,7 +120,7 @@ appendNewEntry(const char *volname, glfs_t *fs)
   UNLOCK(lru_lock);
 
   lruCount++;
-  UNLOCK(gbConf.lock);
+  UNLOCK(gbConf->lock);
 
   return 0;
 }

--- a/utils/lru.c
+++ b/utils/lru.c
@@ -65,6 +65,13 @@ glusterBlockSetLruCount(const size_t lruCount)
   }
 
   LOCK(gbConf->lock);
+  if (gbConf->glfsLruCount == lruCount) {
+    UNLOCK(gbConf->lock);
+    LOG("mgmt", GB_LOG_DEBUG,
+        "No changes to current glfsLruCount: %d, skipping it.",
+        gbConf->glfsLruCount);
+    return 0;
+  }
   gbConf->glfsLruCount = lruCount;
   UNLOCK(gbConf->lock);
 

--- a/utils/utils.h
+++ b/utils/utils.h
@@ -156,7 +156,7 @@ struct gbConf {
   char volServer[HOST_NAME_MAX];
 };
 
-extern struct gbConf gbConf;
+extern struct gbConf *gbConf;
 
 # define  LOG(str, level, fmt, ...)                                    \
           do {                                                         \
@@ -165,16 +165,16 @@ extern struct gbConf gbConf;
             char *tmp;                                                 \
             if (GB_STRDUP(tmp, str) < 0)                               \
               fprintf(stderr, "No memory: %s\n", strerror(errno));     \
-            LOCK(gbConf.lock);                                         \
-            if (level <= gbConf.logLevel) {                            \
+            LOCK(gbConf->lock);                                        \
+            if (level <= gbConf->logLevel) {                           \
               if (!strcmp(tmp, "mgmt"))                                \
-                fd = fopen (gbConf.daemonLogFile, "a");                \
+                fd = fopen (gbConf->daemonLogFile, "a");               \
               else if (!strcmp(tmp, "cli"))                            \
-                fd = fopen (gbConf.cliLogFile, "a");                   \
+                fd = fopen (gbConf->cliLogFile, "a");                  \
               else if (!strcmp(tmp, "gfapi"))                          \
-                fd = fopen (gbConf.gfapiLogFile, "a");                 \
+                fd = fopen (gbConf->gfapiLogFile, "a");                \
               else if (!strcmp(tmp, "cmdlog"))                         \
-                fd = fopen (gbConf.cmdhistoryLogFile, "a");            \
+                fd = fopen (gbConf->cmdhistoryLogFile, "a");           \
               else                                                     \
                 fd = stderr;                                           \
               if (fd == NULL) {                                        \
@@ -190,7 +190,7 @@ extern struct gbConf gbConf;
               if (fd != stderr)                                        \
                 fclose(fd);                                            \
             }                                                          \
-            UNLOCK(gbConf.lock);                                       \
+            UNLOCK(gbConf->lock);                                      \
             GB_FREE(tmp);                                              \
           } while (0)
 
@@ -617,6 +617,9 @@ typedef enum gbDependencies {
   TCMURUNNER       = 1,
   TARGETCLI        = 2,
 } gbDependencies;
+
+int initGbConfig(void);
+void finiGbConfig(void);
 
 int glusterBlockSetLogLevel(unsigned int logLevel);
 


### PR DESCRIPTION
### What does this PR achieve? Why do we need it?

Since we have make the cli and server routines into 2 different
processes in gluster-blockd daemon, the gbConf data will also
be have different copies. If the gbConf data is changed by the
dyn-config thread in the cli(parent) process, the new changes won't
be visible for the server(child) process.

Resolution:
----------
For the gbConf data, use the shared memory instead of the in the
data segment.

