### PR TITLE
rpms: fix compile warnings

### DIFF
--- a/utils/lru.c
+++ b/utils/lru.c
@@ -68,7 +68,7 @@ glusterBlockSetLruCount(const size_t lruCount)
   if (gbConf->glfsLruCount == lruCount) {
     UNLOCK(gbConf->lock);
     LOG("mgmt", GB_LOG_DEBUG,
-        "No changes to current glfsLruCount: %d, skipping it.",
+        "No changes to current glfsLruCount: %lu, skipping it.",
         gbConf->glfsLruCount);
     return 0;
   }

--- a/utils/utils.c
+++ b/utils/utils.c
@@ -98,13 +98,9 @@ glusterBlockSetLogLevel(unsigned int logLevel)
   if (gbCtx == GB_CLI_MODE) {
     dom = "cli";
     level = GB_LOG_DEBUG;
-  } else if (gbCtx == GB_DAEMON_MODE) {
+  } else {
     dom = "mgmt";
     level = GB_LOG_CRIT;
-  }
-
-  if (!dom) {
-    return -EINVAL;
   }
 
   if (logLevel >= GB_LOG_MAX) {
@@ -450,7 +446,7 @@ initLogDirAndFiles(char *newLogDir)
 {
   char *logDir = NULL;
   char *tmpLogDir = NULL;
-  char *dom = NULL;
+  char *dom;
   int ret = 0;
   bool def = false;
   int logLevel;
@@ -459,13 +455,9 @@ initLogDirAndFiles(char *newLogDir)
   if (gbCtx == GB_CLI_MODE) {
     dom = "cli";
     logLevel = GB_LOG_DEBUG;
-  } else if (gbCtx == GB_DAEMON_MODE) {
+  } else {
     dom = "mgmt";
     logLevel = GB_LOG_CRIT;
-  }
-
-  if (!dom) {
-    return -EINVAL;
   }
 
   /*


### PR DESCRIPTION
## What does this PR achieve? Why do we need it?

Fix compile warnings:

```
utils.c: In function 'glusterBlockSetLogLevel':
utils.h:169:23: warning: 'level' may be used uninitialized in this function [-Wmaybe-uninitialized]
             if (level <= gbConf->logLevel) {                           \
                       ^
utils.c:96:7: note: 'level' was declared here
   int level;
       ^
In file included from utils.c:19:0:
utils.h:369:21: warning: 'dom' may be used uninitialized in this function [-Wmaybe-uninitialized]
             gbStrdup(&(dst), src,                                    \
                     ^
utils.c:95:9: note: 'dom' was declared here
   char *dom;
         ^
  CC       libgb_la-lru.lo
lru.c: In function 'glusterBlockSetLruCount':
lru.c:70:5: warning: format '%d' expects argument of type 'int', but argument 5 has type 'size_t' [-Wformat=]
     LOG("mgmt", GB_LOG_DEBUG,
     ^

```

