### PR TITLE
logrotate: remove postrotate action

### DIFF
--- a/extras/gluster-block.logrotate
+++ b/extras/gluster-block.logrotate
@@ -12,7 +12,4 @@
   compress
   delaycompress
   notifempty
-  postrotate
-  killall -q -s 1 gluster-blockd > /dev/null 2>&1 || true
-  endscript
 }


### PR DESCRIPTION
### What does this PR achieve? Why do we need it?
Problem:
---------

Normally we need to capture the SIGHUP in the gluster-blockd daemon,
but since we are fopening and creating the logfiles verytime in LOG(),
so there is no need to do the postrotate action.

Resolution:
------------

Remove the postrotate action in the logrotate config file.


