### PR TITLE
daemon: remove the tcmu-runner active check in systemd case

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -28,6 +28,9 @@ AC_ARG_WITH(systemddir,
             [systemddir='${prefix}/lib/systemd/system'])
 AC_SUBST(systemddir)
 AM_CONDITIONAL([USE_SYSTEMD], test [ -d '/usr/lib/systemd/system' ])
+if test -d '/usr/lib/systemd/system'; then
+    AC_DEFINE([USE_SYSTEMD], [1], [use systemd])
+fi
 
 AC_ARG_WITH(initddir,
             AC_HELP_STRING([--with-initddir=DIR],

--- a/daemon/gluster-blockd.c
+++ b/daemon/gluster-blockd.c
@@ -527,12 +527,18 @@ blockNodeSanityCheck(void)
   char *global_opts;
 
 
+  /*
+   * Systemd service will help to guarantee that the tcmu-runner
+   * is already up when reaching here
+   */
+#ifndef USE_SYSTEMD
   /* Check if tcmu-runner is running */
   ret = gbRunner("ps aux ww | grep -w '[t]cmu-runner' > /dev/null");
   if (ret) {
     LOG("mgmt", GB_LOG_ERROR, "tcmu-runner not running");
     return ESRCH;
   }
+#endif
 
   /* Check targetcli has user:glfs handler listed */
   ret = gbRunner("targetcli /backstores/user:glfs ls > /dev/null");


### PR DESCRIPTION
### What does this PR achieve? Why do we need it?

Systemd service will help to guarantee that the tcmu-runner is already up when reaching here.

To remove this in system case just want to avoid the gap in tcmu-runner and gluster-blockd services that
when the tcmu-runner service is dead, the gluster-blockd service won't exit in time and will be still active for a while, which will still to check the tcmu-runner daemon and exit by itself.

