### PR TITLE
create: fails directly when the StorageObject is already exist with the same NAME

### DIFF
--- a/rpc/block_svc_routines.c
+++ b/rpc/block_svc_routines.c
@@ -41,7 +41,7 @@
                                 "'%s' ls | grep -e tpg -e '%s' | grep -B1 '%s' | grep -o 'tpg\\w'"
 # define   GB_CHECK_PORTAL      "targetcli /iscsi/" GB_TGCLI_IQN_PREFIX \
                                 "'%s' ls | grep '%s' > " DEVNULLPATH
-# define   GB_SAVECONFIG_CHECK  "grep -m 1 '\"name\": \"%s\",' " GB_SAVECONFIG " > " DEVNULLPATH
+# define   GB_SAVECONFIG_SO_CHECK "grep -m 1 '\"config\":.*/block-store/%s\",' " GB_SAVECONFIG " > " DEVNULLPATH
 
 # define   GB_ALUA_AO_TPG_NAME          "glfs_tg_pt_gp_ao"
 # define   GB_ALUA_ANO_TPG_NAME         "glfs_tg_pt_gp_ano"
@@ -294,7 +294,7 @@ blockCheckBlockLoadedStatus(char *block_name, char *gbid, blockResponse *reply)
   }
   GB_FREE(exec);
 
-  if (GB_ASPRINTF(&exec, GB_SAVECONFIG_CHECK, block_name) == -1) {
+  if (GB_ASPRINTF(&exec, GB_SAVECONFIG_SO_CHECK, gbid) == -1) {
     ret = -1;
     goto out;
   }

--- a/utils/utils.h
+++ b/utils/utils.h
@@ -46,6 +46,7 @@
 
 # define   DEVNULLPATH           "/dev/null"
 # define   GB_SAVECONFIG         "/etc/target/saveconfig.json"
+# define   GB_SAVECONFIG_TEMP    "/etc/target/saveconfig.json.temp"
 
 # define  GB_METADIR             "/block-meta"
 # define  GB_STOREDIR            "/block-store"

--- a/utils/utils.h
+++ b/utils/utils.h
@@ -362,6 +362,8 @@ extern struct gbConf *gbConf;
            if (!strstr(out, tmp)) {                                    \
              GB_FREE(tmp);                                             \
              LOG("mgmt", GB_LOG_ERROR, errStr, vol_blk);               \
+             LOG("mgmt", GB_LOG_ERROR, "Error from targetcli:\n%s\n",  \
+                  out);                                                \
              goto label;                                               \
            }                                                           \
            GB_FREE(tmp);                                               \


### PR DESCRIPTION
### What does this PR achieve? Why do we need it?

create: split the creation into 2 phases

This will fix the following issues:

1, When the StorageObject creation failed the iqn will still be
created and won't be deleted in case of:

When creating BV with the same NAME, the second time it will fail
due to the targetcli cache db only allows one [user/$NAME] exist,
but will leave the iqn not deleted correctly.

That means there will be two different Targets will both mapped
to the same StorageObject.

2, For the case above we will also find that after the second
creation failing the /etc/target/saveconfig.json will be one
StorageObject with the second Target in pairs and exist.

In theory, there should be one StorageObject with 2 Targets.

This patch will split the creation into 2 phases: CREATE_SO_SRV
and CREATE_TG_SRV, since in the targetcli it will build the cache
by using the key = [usr/$NAME], so only the StorageObject is
successfully created the second phase will make sense.

### Does this PR fix issues?

Fixes: BZ#1725009



