### PR TITLE
configure.ac: set the libexecdir flexiblly depending on the prefix

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -142,6 +142,8 @@ AC_SUBST(GLUSTER_BLOCKD_WORKDIR)
 if test "x$prefix" = xNONE; then
    test $libexecdir = '${prefix}/libexec' && localstatedir=$ac_default_prefix/libexec
    libexecdir=/usr/libexec
+else
+   libexecdir='${prefix}/libexec'
 fi
 
 GLUSTER_BLOCKD_LIBEXECDIR="$(eval echo ${libexecdir}/gluster-block)"


### PR DESCRIPTION
### What does this PR achieve? Why do we need it?

When doing set the --prefix=XXX the GLUSTER_BLOCKD_LIBEXECDIR will be:

GLUSTER_BLOCKD_LIBEXECDIR=NONE/libexec/gluster-block and when installing
it will be installed in extra/NONE/libexec/gluster-block/.

