### PR TITLE
create: add tcmur_cmd_time_out option support

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,9 +75,11 @@ commands:
                               [storage <filename>]
                               [ring-buffer <size-in-MB-units>]
                               [block-size <size-in-Byte-units>]
+                              [io-timeout <N-in-Second>]
                               <host1[,host2,...]> [size]
         create block device [defaults: ha 1, auth disable, prealloc full, size in bytes,
-                             ring-buffer and block-size default size dependends on kernel]
+                             ring-buffer and block-size default size dependends on kernel,
+                             io-timeout 43s]
 
   list    <volname>
         list available block devices.

--- a/daemon/gluster-blockd.c
+++ b/daemon/gluster-blockd.c
@@ -458,6 +458,14 @@ gbDependenciesVersionCheck(void)
   }
   GB_FREE(out);
 
+  out = gbRunnerGetOutput(CONFIGSHELL_VERSION);
+  if (!out[0]) {
+    LOG("mgmt", GB_LOG_INFO, "starting with configshell version < 1.1.25");
+  } else {
+    LOG("mgmt", GB_LOG_INFO, "starting with configshell version - %s", out);
+  }
+  GB_FREE(out);
+
   return;
 
  out:

--- a/docs/gluster-block.8
+++ b/docs/gluster-block.8
@@ -26,7 +26,7 @@ Note that the gluster-blockd daemon is responsible for block management, hence t
 
 .SH COMMANDS
 .SS
-\fBcreate\fR <VOLNAME/NEW-BLOCKNAME> [ha <COUNT>] [auth <enable|disable>] [prealloc <full|no>] [storage <filename>] [ring-buffer <size-in-MB-units>] [block-size <size-in-Byte-units>] <HOST1[,HOST2,..]> [BYTES]
+\fBcreate\fR <VOLNAME/NEW-BLOCKNAME> [ha <COUNT>] [auth <enable|disable>] [prealloc <full|no>] [storage <filename>] [ring-buffer <size-in-MB-units>] [block-size <size-in-Byte-units>] [io-timeout <N in Second>] <HOST1[,HOST2,..]> [BYTES]
 create block device.
 .TP
 [ha <COUNT>]
@@ -46,6 +46,10 @@ kernel ring buffer size for exchanging iSCSI commands, range [1MB - 1024MB] (def
 .TP
 [block-size <size-in-Byte-units>]
 kernel hw block size, aligns to 512 (default: as per kernel)
+.TP
+[io-timeout <N in Second>]
+time duration for which the tcmu-runner waits to check if the IO from gluster block hosting volume server is responsive. Ideally this value should be kept larger than both IO timeout value (default is 30s) in the iscsi client/initiator side and the gluster ping timeout (default is 42s), (default: 43s)
+
 .TP
 <HOST1,[HOST2....]>
 servers in the pool where targets will be exported

--- a/rpc/block_common.h
+++ b/rpc/block_common.h
@@ -29,7 +29,7 @@
 
 # define   GB_TGCLI_GLFS_PATH   "/backstores/user:glfs"
 # define   GB_TGCLI_GLFS        "targetcli " GB_TGCLI_GLFS_PATH
-# define   GB_TGCLI_CHECK       GB_TGCLI_GLFS " ls | grep ' %s ' | grep '/%s ' > " DEVNULLPATH
+# define   GB_TGCLI_CHECK       GB_TGCLI_GLFS " ls | grep ' %s ' | grep '/%s' > " DEVNULLPATH
 # define   GB_TGCLI_ISCSI_PATH  "/iscsi"
 # define   GB_TGCLI_ISCSI       "targetcli " GB_TGCLI_ISCSI_PATH
 # define   GB_TGCLI_ISCSI_CHECK GB_TGCLI_ISCSI " ls | grep ' %s%s ' > " DEVNULLPATH
@@ -39,6 +39,7 @@
 
 # define   GB_RING_BUFFER_STR   "max_data_area_mb"
 # define   GB_BLOCK_SIZE_STR    "hw_block_size"
+# define   GB_IO_TIMEOUT_STR    "tcmur_cmd_time_out"
 
 #define    GB_CMD_TIME_OUT      130
 

--- a/rpc/block_create.c
+++ b/rpc/block_create.c
@@ -733,16 +733,16 @@ block_create_v2_1_svc_st(blockCreate2 *blk, struct svc_req *rqstp)
   size_t blk_size = 0;
   size_t io_timeout = 0;
   struct gbXdata *xdata_val = (struct gbXdata*)blk->xdata.xdata_val;
-  struct gbCreate3 *gbCreate3 = (struct gbCreate3 *)xdata_val->data;
+  struct gbCreate *gbCreate = (struct gbCreate *)xdata_val->data;
   int n = 0;
 
   if (len > 0 && xdata_val && GB_XDATA_IS_MAGIC(xdata_val->magic)) {
     switch (GB_XDATA_GET_MAGIC_VER(xdata_val->magic)) {
     case 4:
-      io_timeout = gbCreate3->io_timeout;
+      io_timeout = gbCreate->io_timeout;
     case 3:
-      blk_size = gbCreate3->blk_size;
-      volServer = gbCreate3->volServer;
+      blk_size = gbCreate->blk_size;
+      volServer = gbCreate->volServer;
       break;
     default:
       LOG("mgmt", GB_LOG_ERROR, "Shouldn't be here and getting unknown verion number!");
@@ -1081,36 +1081,36 @@ block_create_cli_1_svc_st(blockCreateCli *blk, struct svc_req *rqstp)
 
   if (!resultCaps[GB_CREATE_IO_TIMEOUT_CAP]) { // Create V4
     unsigned int len;
-    struct gbCreate3 *gbCreate3;
+    struct gbCreate *gbCreate;
 
-    len = sizeof(struct gbXdata) + sizeof(struct gbCreate3);
+    len = sizeof(struct gbXdata) + sizeof(struct gbCreate);
     if (GB_ALLOC_N(xdata, len) < 0) {
       errCode = ENOMEM;
       goto exist;
     }
 
     xdata->magic = GB_XDATA_GEN_MAGIC(4);
-    gbCreate3 = (struct gbCreate3 *)(&xdata->data);
-    GB_STRCPY(gbCreate3->volServer, (char *)gbConf->volServer, sizeof(gbConf->volServer));
-    gbCreate3->blk_size = blk->blk_size;
-    gbCreate3->io_timeout = blk->io_timeout;
+    gbCreate = (struct gbCreate *)(&xdata->data);
+    GB_STRCPY(gbCreate->volServer, (char *)gbConf->volServer, sizeof(gbConf->volServer));
+    gbCreate->blk_size = blk->blk_size;
+    gbCreate->io_timeout = blk->io_timeout;
 
     cobj.xdata.xdata_len = len;
     cobj.xdata.xdata_val = (char *)xdata;
   } else if (blk->blk_size) { // Create V3
     unsigned int len;
-    struct gbCreate3 *gbCreate3;
+    struct gbCreate *gbCreate;
 
-    len = sizeof(struct gbXdata) + sizeof(struct gbCreate3);
+    len = sizeof(struct gbXdata) + sizeof(struct gbCreate);
     if (GB_ALLOC_N(xdata, len) < 0) {
       errCode = ENOMEM;
       goto exist;
     }
 
     xdata->magic = GB_XDATA_GEN_MAGIC(3);
-    gbCreate3 = (struct gbCreate3 *)(&xdata->data);
-    GB_STRCPY(gbCreate3->volServer, (char *)gbConf->volServer, sizeof(gbConf->volServer));
-    gbCreate3->blk_size = blk->blk_size;
+    gbCreate = (struct gbCreate *)(&xdata->data);
+    GB_STRCPY(gbCreate->volServer, (char *)gbConf->volServer, sizeof(gbConf->volServer));
+    gbCreate->blk_size = blk->blk_size;
 
     cobj.xdata.xdata_len = len;
     cobj.xdata.xdata_val = (char *)xdata;

--- a/rpc/block_genconfig.c
+++ b/rpc/block_genconfig.c
@@ -138,8 +138,9 @@ getTgObj(char *block, MetaInfo *info, blockGenConfigCli *blk)
 static struct json_object *
 getSoObj(char *block, MetaInfo *info, blockGenConfigCli *blk)
 {
-  char cfgstr[1024] = {'\0', };
+  char cfgstr[2048] = {'\0', };
   char control[1024] = {'\0', };
+  char io_timeout[128] = {'\0', };
   struct json_object *so_obj = json_object_new_object();
   struct json_object *so_obj_alua_ao_tpg;
   struct json_object *so_obj_alua_ano_tpg;
@@ -187,10 +188,16 @@ getSoObj(char *block, MetaInfo *info, blockGenConfigCli *blk)
   json_object_object_add(so_obj, "attributes", so_obj_attr);
   // }
 
+  if (info->io_timeout) {
+    snprintf(io_timeout, 128, ";%s=%lu", GB_IO_TIMEOUT_STR, info->io_timeout);
+  }
+
   if (!strcmp(gbConf->volServer, "localhost")) {
-    snprintf(cfgstr, 1024, "glfs/%s@%s/block-store/%s", info->volume, blk->addr, info->gbid);
+    snprintf(cfgstr, 2048, "glfs/%s@%s/block-store/%s%s", info->volume,
+             blk->addr, info->gbid, io_timeout[0]?io_timeout:"");
   } else {
-    snprintf(cfgstr, 1024, "glfs/%s@%s/block-store/%s", info->volume, gbConf->volServer, info->gbid);
+    snprintf(cfgstr, 2048, "glfs/%s@%s/block-store/%s%s", info->volume,
+             gbConf->volServer, info->gbid, io_timeout[0]?io_timeout:"");
   }
   json_object_object_add(so_obj, "config", GB_JSON_OBJ_TO_STR(cfgstr[0]?cfgstr:NULL));
   if (info->rb_size) {

--- a/rpc/block_info.c
+++ b/rpc/block_info.c
@@ -26,6 +26,7 @@ blockInfoCliFormatResponse(blockInfoCli *blk, int errCode,
   char         *out         = NULL;
   int          i            = 0;
   char         *hr_size     = NULL;           /* Human Readable size */
+  char         *timeout     = NULL;
 
   if (!reply) {
     return;
@@ -67,6 +68,13 @@ blockInfoCliFormatResponse(blockInfoCli *blk, int errCode,
     }
   }
 
+  if (GB_ASPRINTF(&timeout, "%lu Seconds", info->io_timeout) < 0) {
+      GB_ASPRINTF (&errMsg, "failed in blockInfoCliFormatResponse");
+      blockFormatErrorResponse(INFO_SRV, blk->json_resp, ENOMEM,
+                               errMsg, reply);
+      goto out;
+  }
+
   if (blk->json_resp) {
     json_obj = json_object_new_object();
     json_object_object_add(json_obj, "NAME", GB_JSON_OBJ_TO_STR(blk->block_name));
@@ -74,6 +82,7 @@ blockInfoCliFormatResponse(blockInfoCli *blk, int errCode,
     json_object_object_add(json_obj, "GBID", GB_JSON_OBJ_TO_STR(info->gbid));
     json_object_object_add(json_obj, "SIZE", GB_JSON_OBJ_TO_STR(hr_size));
     json_object_object_add(json_obj, "HA", json_object_new_int(info->mpath));
+    json_object_object_add(json_obj, "IOTIMEOUT", GB_JSON_OBJ_TO_STR(timeout));
     json_object_object_add(json_obj, "PASSWORD", GB_JSON_OBJ_TO_STR(info->passwd));
 
     json_array1 = json_object_new_array();
@@ -105,9 +114,9 @@ blockInfoCliFormatResponse(blockInfoCli *blk, int errCode,
     json_object_put(json_obj);
   } else {
     if (GB_ASPRINTF(&tmp, "NAME: %s\nVOLUME: %s\nGBID: %s\nSIZE: %s\n"
-                    "HA: %zu\nPASSWORD: %s\nEXPORTED ON:",
+                    "HA: %zu\nIOTIMEOUT: %s\nPASSWORD: %s\nEXPORTED ON:",
                     blk->block_name, info->volume, info->gbid, hr_size,
-                    info->mpath, info->passwd) == -1) {
+                    info->mpath, timeout, info->passwd) == -1) {
       goto out;
     }
     for (i = 0; i < info->nhosts; i++) {
@@ -150,7 +159,8 @@ blockInfoCliFormatResponse(blockInfoCli *blk, int errCode,
     blockFormatErrorResponse(INFO_SRV, blk->json_resp, errCode,
                              GB_DEFAULT_ERRMSG, reply);
   }
-  GB_FREE(hr_size);
+  GB_FREE (hr_size);
+  GB_FREE (timeout);
   GB_FREE (tmp);
   GB_FREE (tmp2);
   GB_FREE (tmp3);

--- a/rpc/block_replace.c
+++ b/rpc/block_replace.c
@@ -124,34 +124,34 @@ glusterBlockReplaceNodeRemoteAsync(struct glfs *glfs, blockReplaceCli *blk,
 
   if (info->io_timeout) { // Create V4
     unsigned int len;
-    struct gbCreate3 *gbCreate3;
+    struct gbCreate *gbCreate;
 
-    len = sizeof(struct gbXdata) + sizeof(struct gbCreate3);
+    len = sizeof(struct gbXdata) + sizeof(struct gbCreate);
     if (GB_ALLOC_N(xdata, len) < 0) {
 	goto out;
     }
 
     xdata->magic = GB_XDATA_GEN_MAGIC(4);
-    gbCreate3 = (struct gbCreate3 *)(&xdata->data);
-    GB_STRCPY(gbCreate3->volServer, (char *)gbConf->volServer, sizeof(gbConf->volServer));
-    gbCreate3->blk_size = info->blk_size;
-    gbCreate3->io_timeout = info->io_timeout;
+    gbCreate = (struct gbCreate *)(&xdata->data);
+    GB_STRCPY(gbCreate->volServer, (char *)gbConf->volServer, sizeof(gbConf->volServer));
+    gbCreate->blk_size = info->blk_size;
+    gbCreate->io_timeout = info->io_timeout;
 
     cobj->xdata.xdata_len = len;
     cobj->xdata.xdata_val = (char *)xdata;
   } else if (info->blk_size) { // Create V3
     unsigned int len;
-    struct gbCreate3 *gbCreate3;
+    struct gbCreate *gbCreate;
 
-    len = sizeof(struct gbXdata) + sizeof(struct gbCreate3);
+    len = sizeof(struct gbXdata) + sizeof(struct gbCreate);
     if (GB_ALLOC_N(xdata, len) < 0) {
 	goto out;
     }
 
     xdata->magic = GB_XDATA_GEN_MAGIC(3);
-    gbCreate3 = (struct gbCreate3 *)(&xdata->data);
-    GB_STRCPY(gbCreate3->volServer, (char *)gbConf->volServer, sizeof(gbConf->volServer));
-    gbCreate3->blk_size = info->blk_size;
+    gbCreate = (struct gbCreate *)(&xdata->data);
+    GB_STRCPY(gbCreate->volServer, (char *)gbConf->volServer, sizeof(gbConf->volServer));
+    gbCreate->blk_size = info->blk_size;
 
     cobj->xdata.xdata_len = len;
     cobj->xdata.xdata_val = (char *)xdata;

--- a/rpc/block_replace.c
+++ b/rpc/block_replace.c
@@ -122,7 +122,24 @@ glusterBlockReplaceNodeRemoteAsync(struct glfs *glfs, blockReplaceCli *blk,
     goto out;
   }
 
-  if (info->blk_size) { // Create V3
+  if (info->io_timeout) { // Create V4
+    unsigned int len;
+    struct gbCreate3 *gbCreate3;
+
+    len = sizeof(struct gbXdata) + sizeof(struct gbCreate3);
+    if (GB_ALLOC_N(xdata, len) < 0) {
+	goto out;
+    }
+
+    xdata->magic = GB_XDATA_GEN_MAGIC(4);
+    gbCreate3 = (struct gbCreate3 *)(&xdata->data);
+    GB_STRCPY(gbCreate3->volServer, (char *)gbConf->volServer, sizeof(gbConf->volServer));
+    gbCreate3->blk_size = info->blk_size;
+    gbCreate3->io_timeout = info->io_timeout;
+
+    cobj->xdata.xdata_len = len;
+    cobj->xdata.xdata_val = (char *)xdata;
+  } else if (info->blk_size) { // Create V3
     unsigned int len;
     struct gbCreate3 *gbCreate3;
 

--- a/rpc/block_version.c
+++ b/rpc/block_version.c
@@ -52,6 +52,9 @@ glusterBlockBuildMinCaps(void *data, operations opt)
     if (cblk->json_resp) {
       minCaps[GB_JSON_CAP] = true;
     }
+    if (cblk->io_timeout) {
+      minCaps[GB_CREATE_IO_TIMEOUT_CAP] = true;
+    }
     break;
   case DELETE_SRV:
     dblk = (blockDeleteCli *)data;

--- a/rpc/glfs-operations.c
+++ b/rpc/glfs-operations.c
@@ -610,6 +610,9 @@ blockStuffMetaInfo(MetaInfo *info, char *line)
   case GB_META_RINGBUFFER:
     sscanf(strchr(line, ' '), "%zu", &info->rb_size);
     break;
+  case GB_META_IO_TIMEOUT:
+    sscanf(strchr(line, ' '), "%lu", &info->io_timeout);
+    break;
   case GB_META_BLKSIZE:
     sscanf(strchr(line, ' '), "%zu", &info->blk_size);
     break;

--- a/rpc/glfs-operations.h
+++ b/rpc/glfs-operations.h
@@ -34,6 +34,7 @@ typedef struct MetaInfo {
   size_t size;
   size_t rb_size;
   size_t blk_size;
+  size_t io_timeout;
   char   prio_path[255];
   size_t mpath;
   char   entry[16];  /* possible strings for ENTRYCREATE: INPROGRESS|SUCCESS|FAIL */

--- a/rpc/rpcl/block.x
+++ b/rpc/rpcl/block.x
@@ -67,6 +67,7 @@ struct blockCreateCli {
   u_quad_t  size;
   u_int     rb_size;              /* TCMU Ring Buffer size in kernel */
   u_int     blk_size;             /* TCMU hw block size in kernel */
+  u_int     io_timeout;           /* Cmds timeout in tcmu-runner */
   u_int     mpath;                /* HA request count */
   bool      auth_mode;
   bool      prealloc;

--- a/tests/basic.t
+++ b/tests/basic.t
@@ -125,6 +125,10 @@ TEST gluster-block delete ${VOLNAME}/${BLKNAME}
 TEST gluster-block create ${VOLNAME}/${BLKNAME} ring-buffer 32 ${HOST} 1MiB
 TEST gluster-block delete ${VOLNAME}/${BLKNAME}
 
+# Block create with 'io-timeout' set/delete
+TEST gluster-block create ${VOLNAME}/${BLKNAME} io-timeout 44 ${HOST} 1MiB
+TEST gluster-block delete ${VOLNAME}/${BLKNAME}
+
 # Block create with 'block-size' set/delete
 TEST gluster-block create ${VOLNAME}/${BLKNAME} block-size 1024 ${HOST} 1MiB
 TEST gluster-block delete ${VOLNAME}/${BLKNAME}

--- a/utils/capabilities.c
+++ b/utils/capabilities.c
@@ -36,6 +36,31 @@ gbCapabilitiesEnumParse(const char *cap)
 }
 
 
+bool
+gbIoTimeoutDependenciesVersionCheck(void)
+{
+  char *out = NULL;
+  int ret = true;
+
+
+  out = gbRunnerGetOutput(CONFIGSHELL_VERSION);
+  if (!gbDependencyVersionCompare(CONFIGSHELL_SEMICOLON, out)) {
+    ret = false;
+    goto out;
+  }
+
+  GB_FREE(out);
+  out = gbRunnerGetOutput(TCMU_VERSION);
+  if (!gbDependencyVersionCompare(TCMURUNNER_IO_TIMEOUT, out)) {
+    ret = false;
+  }
+
+out:
+  GB_FREE(out);
+  return ret;
+}
+
+
 static bool
 gbBlockSizeDependenciesVersionCheck(void)
 {
@@ -141,6 +166,16 @@ gbSetCapabilties(void)
             LOG ("mgmt", GB_LOG_WARNING,
                  "reload needs atleast targetcli >=%s and rtslib >= %s, so disabling its capability",
                  GB_MIN_TARGETCLI_RELOAD_VERSION, GB_MIN_RTSLIB_RELOAD_VERSION);
+            caps[count].status = 0;
+            count++;
+            GB_FREE(line);
+            continue;
+          }
+      } else if (ret == GB_CREATE_IO_TIMEOUT_CAP) {
+          if (!gbIoTimeoutDependenciesVersionCheck()) {
+            LOG ("mgmt", GB_LOG_WARNING,
+                 "io timeout needs atleast configshell >=%s and tcmu-runner >= %s, so disabling its capability",
+                 GB_MIN_CONFIGSHELL_SEM_VERSION, GB_MIN_TCMURUNNER_IO_TIMEOUT_VERSION);
             caps[count].status = 0;
             count++;
             GB_FREE(line);

--- a/utils/capabilities.h
+++ b/utils/capabilities.h
@@ -50,6 +50,8 @@ enum gbCapabilities {
 
   GB_RELOAD_CAP,
 
+  GB_CREATE_IO_TIMEOUT_CAP,
+
   GB_CAP_MAX
 };
 
@@ -62,6 +64,7 @@ static const char *const gbCapabilitiesLookup[] = {
   [GB_CREATE_RING_BUFFER_CAP]  = "create_ring_buffer",
   [GB_CREATE_LOAD_BALANCE_CAP] = "create_load_balance",
   [GB_CREATE_BLOCK_SIZE_CAP]   = "create_block_size",
+  [GB_CREATE_IO_TIMEOUT_CAP]   = "create_io_timeout",
 
   [GB_DELETE_CAP]              = "delete",
   [GB_DELETE_FORCE_CAP]        = "delete_force",
@@ -85,3 +88,4 @@ extern gbCapObj *globalCapabilities;
 
 int gbCapabilitiesEnumParse(const char *cap);
 void gbSetCapabilties(void);
+bool gbIoTimeoutDependenciesVersionCheck(void);

--- a/utils/gluster-block-caps.info
+++ b/utils/gluster-block-caps.info
@@ -160,3 +160,14 @@ create_block_size: true
 # Since: 0.5
 ##
 reload: true
+
+##
+# Nature: cli sub-command
+#
+# Label: 'io-timeout'
+#
+# Description: capability to create block with given cmds timeout value in tcmu-runner
+#
+# Since: 0.5
+##
+create_io_timeout: true

--- a/utils/utils.c
+++ b/utils/utils.c
@@ -416,7 +416,16 @@ gbDependencyVersionCompare(int dependencyName, char *version)
       ret = true;
     }
     break;
-
+  case CONFIGSHELL_SEMICOLON:
+    if (DEPENDENCY_VERSION(vNum[0], vNum[1], vNum[2]) >= GB_MIN_CONFIGSHELL_SEM_VERSION_CODE) {
+      ret = true;
+    }
+    break;
+  case TCMURUNNER_IO_TIMEOUT:
+    if (DEPENDENCY_VERSION(vNum[0], vNum[1], vNum[2]) >= GB_MIN_TCMURUNNER_IO_TIMEOUT_VERSION_CODE) {
+      ret = true;
+    }
+    break;
   }
 
   GB_FREE(verStr);

--- a/utils/utils.h
+++ b/utils/utils.h
@@ -42,6 +42,8 @@
 # define  GB_TCP_PORT            24010
 # define  GB_TCP_PORT_STR        "24010"
 
+# define  GB_IO_TIMEOUT_DEF      43
+
 # define  GFAPI_LOG_LEVEL        7
 
 # define   DEVNULLPATH           "/dev/null"
@@ -177,6 +179,7 @@ struct gbXdata {
 struct gbCreate3 {
   char volServer[HOST_NAME_MAX];
   size_t blk_size;
+  size_t io_timeout;
 };
 
 extern struct gbConf *gbConf;
@@ -467,25 +470,27 @@ static const char *const gbCliCmdlineOptLookup[] = {
 };
 
 typedef enum gbCliCreateOptions {
-  GB_CLI_CREATE_UNKNOWN   = 0,
-  GB_CLI_CREATE_HA        = 1,
-  GB_CLI_CREATE_AUTH      = 2,
-  GB_CLI_CREATE_PREALLOC  = 3,
-  GB_CLI_CREATE_STORAGE   = 4,
-  GB_CLI_CREATE_RBSIZE    = 5,
-  GB_CLI_CREATE_BLKSIZE   = 6,
+  GB_CLI_CREATE_UNKNOWN    = 0,
+  GB_CLI_CREATE_HA         = 1,
+  GB_CLI_CREATE_AUTH       = 2,
+  GB_CLI_CREATE_PREALLOC   = 3,
+  GB_CLI_CREATE_STORAGE    = 4,
+  GB_CLI_CREATE_RBSIZE     = 5,
+  GB_CLI_CREATE_BLKSIZE    = 6,
+  GB_CLI_CREATE_IO_TIMEOUT = 7,
 
   GB_CLI_CREATE_OPT_MAX
 } gbCliCreateOptions;
 
 static const char *const gbCliCreateOptLookup[] = {
-  [GB_CLI_CREATE_UNKNOWN]  = "NONE",
-  [GB_CLI_CREATE_HA]       = "ha",
-  [GB_CLI_CREATE_AUTH]     = "auth",
-  [GB_CLI_CREATE_PREALLOC] = "prealloc",
-  [GB_CLI_CREATE_STORAGE]  = "storage",
-  [GB_CLI_CREATE_RBSIZE]   = "ring-buffer",
-  [GB_CLI_CREATE_BLKSIZE]  = "block-size",
+  [GB_CLI_CREATE_UNKNOWN]    = "NONE",
+  [GB_CLI_CREATE_HA]         = "ha",
+  [GB_CLI_CREATE_AUTH]       = "auth",
+  [GB_CLI_CREATE_PREALLOC]   = "prealloc",
+  [GB_CLI_CREATE_STORAGE]    = "storage",
+  [GB_CLI_CREATE_RBSIZE]     = "ring-buffer",
+  [GB_CLI_CREATE_BLKSIZE]    = "block-size",
+  [GB_CLI_CREATE_IO_TIMEOUT] = "io-timeout",
 
   [GB_CLI_CREATE_OPT_MAX]  = NULL,
 };
@@ -559,6 +564,7 @@ typedef enum Metakey {
   GB_META_RINGBUFFER  = 7,
   GB_META_PRIOPATH    = 8,
   GB_META_BLKSIZE     = 9,
+  GB_META_IO_TIMEOUT  = 10,
 
   GB_METAKEY_MAX
 } Metakey;
@@ -574,6 +580,7 @@ static const char *const MetakeyLookup[] = {
   [GB_META_RINGBUFFER]  = "RINGBUFFER",
   [GB_META_PRIOPATH]    = "PRIOPATH",
   [GB_META_BLKSIZE]     = "BLKSIZE",
+  [GB_META_IO_TIMEOUT]  = "IOTIMEOUT",
 
   [GB_METAKEY_MAX]      = NULL
 };
@@ -660,11 +667,13 @@ typedef struct gbConfig {
 } gbConfig;
 
 typedef enum gbDependencies {
-  TCMURUNNER       = 1,
-  TARGETCLI        = 2,
-  RTSLIB_BLKSIZE   = 3,
-  TARGETCLI_RELOAD = 4,
-  RTSLIB_RELOAD    = 5,
+  TCMURUNNER              = 1,
+  TARGETCLI               = 2,
+  RTSLIB_BLKSIZE          = 3,
+  TARGETCLI_RELOAD        = 4,
+  RTSLIB_RELOAD           = 5,
+  CONFIGSHELL_SEMICOLON   = 6,
+  TCMURUNNER_IO_TIMEOUT   = 7,
 } gbDependencies;
 
 int initGbConfig(void);

--- a/utils/utils.h
+++ b/utils/utils.h
@@ -176,7 +176,7 @@ struct gbXdata {
   char data[];
 };
 
-struct gbCreate3 {
+struct gbCreate {
   char volServer[HOST_NAME_MAX];
   size_t blk_size;
   size_t io_timeout;

--- a/version.h
+++ b/version.h
@@ -17,9 +17,10 @@
 
 # define  DEPENDENCY_VERSION   KERNEL_VERSION
 
-# define  TARGETCLI_VERSION  "targetcli --version 2>&1 | awk -F' ' '{printf $NF}'"
-# define  RTSLIB_VERSION     "python -c 'from rtslib_fb import __version__; print(__version__)'"
-# define  TCMU_VERSION       "tcmu-runner --version 2>&1 | awk -F' ' '{printf $NF}'"
+# define  TARGETCLI_VERSION   "targetcli --version 2>&1 | awk -F' ' '{printf $NF}'"
+# define  RTSLIB_VERSION      "python -c 'from rtslib_fb import __version__; print(__version__)'"
+# define  TCMU_VERSION        "tcmu-runner --version 2>&1 | awk -F' ' '{printf $NF}'"
+# define  CONFIGSHELL_VERSION "python -c 'from configshell_fb import __version__; print(__version__)'"
 
 # define  GLUSTER_BLOCK_VERSION                "0.4"
 
@@ -31,11 +32,15 @@
 # define  GB_MIN_RTSLIB_BLKSIZE_VERSION        "2.1.69"
 # define  GB_MIN_TARGETCLI_RELOAD_VERSION      "2.1.fb50"
 # define  GB_MIN_RTSLIB_RELOAD_VERSION         "2.1.71"
+# define  GB_MIN_CONFIGSHELL_SEM_VERSION       "1.1.25"
+# define  GB_MIN_TCMURUNNER_IO_TIMEOUT_VERSION "1.5.0"
 
-# define  GB_MIN_TCMURUNNER_VERSION_CODE       DEPENDENCY_VERSION(1, 1, 3)
-# define  GB_MIN_TARGETCLI_VERSION_CODE        DEPENDENCY_VERSION(2, 1, 49)
-# define  GB_MIN_RTSLIB_BLKSIZE_VERSION_CODE   DEPENDENCY_VERSION(2, 1, 69)
-# define  GB_MIN_TARGETCLI_RELOAD_VERSION_CODE DEPENDENCY_VERSION(2, 1, 50)
-# define  GB_MIN_RTSLIB_RELOAD_VERSION_CODE    DEPENDENCY_VERSION(2, 1, 71)
+# define  GB_MIN_TCMURUNNER_VERSION_CODE            DEPENDENCY_VERSION(1, 1, 3)
+# define  GB_MIN_TARGETCLI_VERSION_CODE             DEPENDENCY_VERSION(2, 1, 49)
+# define  GB_MIN_RTSLIB_BLKSIZE_VERSION_CODE        DEPENDENCY_VERSION(2, 1, 69)
+# define  GB_MIN_TARGETCLI_RELOAD_VERSION_CODE      DEPENDENCY_VERSION(2, 1, 50)
+# define  GB_MIN_RTSLIB_RELOAD_VERSION_CODE         DEPENDENCY_VERSION(2, 1, 71)
+# define  GB_MIN_CONFIGSHELL_SEM_VERSION_CODE       DEPENDENCY_VERSION(1, 1, 25)
+# define  GB_MIN_TCMURUNNER_IO_TIMEOUT_VERSION_CODE DEPENDENCY_VERSION(1, 5, 0)
 
 # endif /* _VERSION_H */


### PR DESCRIPTION
### What does this PR achieve? Why do we need it?

Set the tcmur_cmd_time_out=43s as default, which is larger than each IO's
timeout value(default is 30s) in the client/initiator side, and
at the same time it will be larger than 42s, the Gluster ping
timeout.


### Does this PR fix issues?
No

### Notes for the reviewer
This depends on the following two PRs:
[1] https://github.com/open-iscsi/configshell-fb/pull/47
[2] https://github.com/open-iscsi/tcmu-runner/pull/568
