### PR TITLE
ringbuffer: fix the max limited size to 1024M

### DIFF
--- a/cli/gluster-block.c
+++ b/cli/gluster-block.c
@@ -685,11 +685,11 @@ glusterBlockCreate(int argcount, char **options, int json)
     case GB_CLI_CREATE_RBSIZE:
       if (isNumber(options[optind])) {
         sscanf(options[optind++], "%u", &cobj.rb_size);
-        if (cobj.rb_size < 1 || cobj.rb_size > 64) {
-          MSG(stderr, "'ring-buffer' should be in range [1MB - 64MB]");
+        if (cobj.rb_size < 1 || cobj.rb_size > 1024) {
+          MSG(stderr, "'ring-buffer' should be in range [1MB - 1024MB]");
           MSG(stderr, GB_CREATE_HELP_STR);
           LOG("cli", GB_LOG_ERROR,
-              "failed while parsing ring-buffer range [1MB - 64MB] for block <%s/%s>",
+              "failed while parsing ring-buffer range [1MB - 1024MB] for block <%s/%s>",
               cobj.volume, cobj.block_name);
         goto out;
         }

--- a/docs/gluster-block.8
+++ b/docs/gluster-block.8
@@ -42,7 +42,7 @@ authentication setting (default: disable)
 existing file(only name) in the gluster volume, that needs to be linked while creating block (default: creates a new file)
 .TP
 [ring-buffer <size-in-MB-units>]
-kernel ring buffer size for exchanging iSCSI commands, range [1MB - 64MB] (default: as per kernel)
+kernel ring buffer size for exchanging iSCSI commands, range [1MB - 1024MB] (default: as per kernel)
 .TP
 [block-size <size-in-Byte-units>]
 kernel hw block size, aligns to 512 (default: as per kernel)


### PR DESCRIPTION
### What does this PR achieve? Why do we need it?

The ringbuffer size for each target could up to the global limitation
which is 2GB, here we will allow it up to 1GB. This relevant kernel
patch has been updated into the same verions with the dynamic growth
and shrink patch set.

### Does this PR fix issues?

No.

### Notes for the reviewer


