### PR TITLE
genconfig: fix one compile warning

### DIFF
--- a/rpc/block_genconfig.c
+++ b/rpc/block_genconfig.c
@@ -22,7 +22,11 @@ getTpgObj(char *block, MetaInfo *info, blockGenConfigCli *blk, char *portal, int
   uuid_t uuid;
   char alias[UUID_BUF_SIZE];
   char alias_10[11] = {'\0', };
-  char lun_so[256] = {'\0', };
+  /*
+   * 256 + extra 32 bytes for string "/backstores/user/" to
+   * suppress the truncated warning when compiling.
+   */
+  char lun_so[288] = {'\0', };
 
   struct json_object *tpg_obj = json_object_new_object();
   struct json_object *tpg_attr_obj = json_object_new_object();
@@ -63,7 +67,7 @@ getTpgObj(char *block, MetaInfo *info, blockGenConfigCli *blk, char *portal, int
   uuid_unparse(uuid, alias);
   snprintf(alias_10, 11, "%.10s", alias+24);
   json_object_object_add(tpg_lun_obj, "alias", GB_JSON_OBJ_TO_STR(alias_10[0]?alias_10:NULL));
-  snprintf(lun_so, 256, "/backstores/user/%s", block);
+  snprintf(lun_so, 288, "/backstores/user/%s", block);
   if (info->prio_path[0]) {
     if (!strcmp(info->prio_path, portal)) {
       json_object_object_add(tpg_lun_obj, "alua_tg_pt_gp_name",


### PR DESCRIPTION
block_genconfig.c: In function 'block_gen_config_cli_1_svc':
block_genconfig.c:66:43: warning: '%s' directive output may be truncated writing up to 255 bytes into a region of size 239 [-Wformat-truncation=]
   66 |   snprintf(lun_so, 256, "/backstores/user/%s", block);
      |                                           ^~
In file included from /usr/include/stdio.h:867,
                 from ../utils/utils.h:16,
                 from ../utils/common.h:15,
                 from block_common.h:16,
                 from block_genconfig.c:12:
/usr/include/bits/stdio2.h:67:10: note: '__builtin___snprintf_chk' output between 18 and 273 bytes into a destination of size 256
   67 |   return __builtin___snprintf_chk (__s, __n, __USE_FORTIFY_LEVEL - 1,
      |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   68 |        __bos (__s), __fmt, __va_arg_pack ());
      |        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

Signed-off-by: Xiubo Li <xiubli@redhat.com>

<!--
Thanks for sending a pull request! Your contribution is very much appreciated.

Here are some tips for you:

1. Split the changes up into minimal and atomic commits.
2. Please write a good description about your changes in commit message.
3. Write a meaningful PR text. Remember: one PR per feature or bugfix. If in doubt, split your patchset into multiple PRs.
-->

### What does this PR achieve? Why do we need it?


### Does this PR fix issues?

<!-- This is optional, 'Fixes: #<issue-number>' lines will close the issue if the PR is merged.  -->

Fixes: #


### Notes for the reviewer


