### PR TITLE
genconfig: switch to string instead of fixed 255 for the volume

### DIFF
--- a/cli/gluster-block.c
+++ b/cli/gluster-block.c
@@ -1074,7 +1074,7 @@ glusterBlockReplace(int argcount, char **options, int json)
 static int
 glusterBlockGenConfig(int argcount, char **options, int json)
 {
-  blockGenConfigCli robj = {{0},};
+  blockGenConfigCli robj = {0,};
   int ret = -1;
   int optind = 1;
 
@@ -1087,7 +1087,7 @@ glusterBlockGenConfig(int argcount, char **options, int json)
     goto out;
   }
 
-  GB_STRCPYSTATIC(robj.volume, options[optind++]);
+  GB_STRDUP(robj.volume, options[optind++]);
 
   if (!strcmp(options[optind++], "enable-tpg")) {
     if (!glusterBlockIsAddrAcceptable(options[optind])) {
@@ -1098,7 +1098,7 @@ glusterBlockGenConfig(int argcount, char **options, int json)
     GB_STRCPYSTATIC(robj.addr, options[optind]);
   } else {
       MSG(stderr, "unknown option '%s' for genconfig:\n%s", options[optind -1], GB_GENCONF_HELP_STR);
-      return -1;
+      goto out;
   }
   robj.json_resp = json;
 
@@ -1108,6 +1108,7 @@ glusterBlockGenConfig(int argcount, char **options, int json)
   }
 
  out:
+  GB_FREE(robj.volume);
 
   return ret;
 }

--- a/rpc/rpcl/block.x
+++ b/rpc/rpcl/block.x
@@ -145,7 +145,7 @@ struct blockReplaceCli {
 };
 
 struct blockGenConfigCli {
-  char      volume[255];
+  string    volume<>;
   char      addr[255];
   enum JsonResponseFormat     json_resp;
 };


### PR DESCRIPTION
<!--
Thanks for sending a pull request! Your contribution is very much appreciated.

Here are some tips for you:

1. Split the changes up into minimal and atomic commits.
2. Please write a good description about your changes in commit message.
3. Write a meaningful PR text. Remember: one PR per feature or bugfix. If in doubt, split your patchset into multiple PRs.
-->

### What does this PR achieve? Why do we need it?
If we specify more than 2 volumes in one genconfig command line,
the genconfig will truncate the volumes.


### Does this PR fix issues?
Yeah


<!-- This is optional, 'Fixes: #<issue-number>' lines will close the issue if the PR is merged.  -->

Fixes: #1787371


### Notes for the reviewer


