### PR TITLE
resize: update the size in metafile soon after ResizeEntry

### DIFF
--- a/rpc/block_info.c
+++ b/rpc/block_info.c
@@ -46,33 +46,20 @@ blockInfoCliFormatResponse(blockInfoCli *blk, int errCode,
   if (!info)
     goto out;
 
-  for (i = 0; i < info->nhosts; i++) {
-    switch (blockMetaStatusEnumParse(info->list[i]->status)) {
-    case GB_RS_INPROGRESS:
-    case GB_RS_FAIL:
-      GB_STRDUP(hr_size, "-");
-      break;
-    }
-    if (hr_size) {
-      break;
-    }
-  }
+  hr_size = glusterBlockFormatSize("mgmt", info->size);
   if (!hr_size) {
-    hr_size = glusterBlockFormatSize("mgmt", info->size);
-    if (!hr_size) {
-      GB_ASPRINTF (&errMsg, "failed in glusterBlockFormatSize");
-      blockFormatErrorResponse(INFO_SRV, blk->json_resp, ENOMEM,
-                               errMsg, reply);
-      GB_FREE(errMsg);
-      goto out;
-    }
+    GB_ASPRINTF (&errMsg, "failed in glusterBlockFormatSize");
+    blockFormatErrorResponse(INFO_SRV, blk->json_resp, ENOMEM,
+                             errMsg, reply);
+    GB_FREE(errMsg);
+    goto out;
   }
 
   if (GB_ASPRINTF(&timeout, "%lu Seconds", info->io_timeout) < 0) {
-      GB_ASPRINTF (&errMsg, "failed in blockInfoCliFormatResponse");
-      blockFormatErrorResponse(INFO_SRV, blk->json_resp, ENOMEM,
-                               errMsg, reply);
-      goto out;
+    GB_ASPRINTF (&errMsg, "failed in blockInfoCliFormatResponse");
+    blockFormatErrorResponse(INFO_SRV, blk->json_resp, ENOMEM,
+                             errMsg, reply);
+    goto out;
   }
 
   if (blk->json_resp) {

--- a/rpc/block_modify.c
+++ b/rpc/block_modify.c
@@ -890,6 +890,9 @@ block_modify_size_cli_1_svc_st(blockModifySizeCli *blk, struct svc_req *rqstp)
     goto out;
   }
 
+  GB_METAUPDATE_OR_GOTO(lock, glfs, mobj.block_name, mobj.volume,
+                        errCode, errMsg, out, "SIZE: %zu\n",  mobj.size);
+
   asyncret = glusterBlockModifySizeRemoteAsync(info, glfs, &mobj, &savereply);
   if (asyncret) {   /* asyncret decides result is success/fail */
     errCode = asyncret;
@@ -897,9 +900,6 @@ block_modify_size_cli_1_svc_st(blockModifySizeCli *blk, struct svc_req *rqstp)
         "glusterBlockModifySizeRemoteAsync(size=%zu): return %d %s for block %s on volume %s",
         blk->size, asyncret, FAILED_REMOTE_AYNC_MODIFY, blk->block_name, info->volume);
     goto out;
-  } else {
-    GB_METAUPDATE_OR_GOTO(lock, glfs, mobj.block_name, mobj.volume,
-                          errCode, errMsg, out, "SIZE: %zu\n",  mobj.size);
   }
 
  out:


### PR DESCRIPTION

<!--
Thanks for sending a pull request! Your contribution is very much appreciated.

Here are some tips for you:

1. Split the changes up into minimal and atomic commits.
2. Please write a good description about your changes in commit message.
3. Write a meaningful PR text. Remember: one PR per feature or bugfix. If in doubt, split your patchset into multiple PRs.
-->

### What does this PR achieve? Why do we need it?

On a resize operation, say the backend file expand succeed but the config
change on a remote node failed. In this case, the block hosting volume size
is already occupied. Hence the block volume info should return the currently
consumed size.

Signed-off-by: Prasanna Kumar Kalever <prasanna.kalever@redhat.com>


### Notes for the reviewer
Needed-by: https://github.com/heketi/heketi/pull/1702

