### PR TITLE
vagrant: disable QEMU session support

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -15,6 +15,8 @@ Vagrant.configure("2") do |config|
   config.vm.provider "libvirt" do |lv|
     lv.cpus = "2"
     lv.memory = "2048"
+    # Always use system connection instead of QEMU session
+    lv.qemu_use_session = false
   end
 
   # disable default sync dir


### PR DESCRIPTION

<!--
Thanks for sending a pull request! Your contribution is very much appreciated.

Here are some tips for you:

1. Split the changes up into minimal and atomic commits.
2. Please write a good description about your changes in commit message.
3. Write a meaningful PR text. Remember: one PR per feature or bugfix. If in doubt, split your patchset into multiple PRs.
-->

### What does this PR achieve? Why do we need it?

vagrant-libvirt supports using QEMU user sessions to maintain Vagrant
VMs, and some distros turn it ON by default.

After upgrading to Fedora32 I have noticed `vagrant up` fails with a huge call
trace and disabling QEMU session worked.

More read:
https://github.com/vagrant-libvirt/vagrant-libvirt#qemu-session-support
https://fedoraproject.org/wiki/Changes/Vagrant_2.2_with_QEMU_Session

Signed-off-by: Prasanna Kumar Kalever \<prasanna.kalever@redhat.com\>


