### PR TITLE
CVE fixes master

### DIFF
--- a/rpc/block_create.c
+++ b/rpc/block_create.c
@@ -454,10 +454,10 @@ block_create_common(blockCreate *blk, char *control, char *volServer,
 
   LOG("mgmt", GB_LOG_INFO,
       "create request, volume=%s volserver=%s blockname=%s blockhosts=%s "
-      "filename=%s authmode=%d passwd=%s size=%lu control=%s "
-      "io_timeout=%lu", blk->volume, volServer?volServer:blk->ipaddr,
-      blk->block_name, blk->block_hosts, blk->gbid, blk->auth_mode,
-      blk->auth_mode?blk->passwd:"", blk->size, control?control:"", io_timeout);
+      "filename=%s authmode=%d size=%lu control=%s io_timeout=%lu",
+      blk->volume, volServer?volServer:blk->ipaddr, blk->block_name,
+      blk->block_hosts, blk->gbid, blk->auth_mode, blk->size,
+      control?control:"", io_timeout);
 
   if (GB_ALLOC(reply) < 0) {
     goto out;
@@ -956,6 +956,7 @@ block_create_cli_1_svc_st(blockCreateCli *blk, struct svc_req *rqstp)
   blockCreate2 cobj = {{0},};
   bool *resultCaps = NULL;
   struct gbXdata *xdata = NULL;
+  char *cmdlog = NULL;
 
 
   LOG("mgmt", GB_LOG_INFO,
@@ -1169,8 +1170,12 @@ block_create_cli_1_svc_st(blockCreateCli *blk, struct svc_req *rqstp)
       errCode ? "failure" : "success", blk->volume, blk->block_name);
 
   blockCreateCliFormatResponse(glfs, blk, &cobj, errCode, errMsg, savereply, reply);
+  if (reply) {
+    cmdlog = gbClipoffSensitiveDetails(reply->out);
+  }
   LOG("cmdlog", ((!!errCode) ? GB_LOG_ERROR : GB_LOG_INFO), "%s",
-      reply ? reply->out : "*Nil*");
+      cmdlog ? cmdlog : "*Nil*");
+  GB_FREE(cmdlog);
   GB_FREE(errMsg);
   blockServerDefFree(list);
   blockCreateParsedRespFree(savereply);

--- a/rpc/block_info.c
+++ b/rpc/block_info.c
@@ -215,6 +215,7 @@ block_info_cli_1_svc_st(blockInfoCli *blk, struct svc_req *rqstp)
   MetaInfo *info = NULL;
   int errCode = -1;
   char *errMsg = NULL;
+  char *cmdlog = NULL;
 
 
   LOG("mgmt", GB_LOG_INFO,
@@ -271,8 +272,12 @@ block_info_cli_1_svc_st(blockInfoCli *blk, struct svc_req *rqstp)
 
 
   blockInfoCliFormatResponse(blk, errCode, errMsg, info, reply);
+  if (reply) {
+    cmdlog = gbClipoffSensitiveDetails(reply->out);
+  }
   LOG("cmdlog", ((!!errCode) ? GB_LOG_ERROR : GB_LOG_INFO), "%s",
-      reply ? reply->out : "*Nil*");
+      cmdlog ? cmdlog : "*Nil*");
+  GB_FREE(cmdlog);
   GB_FREE(errMsg);
   blockFreeMetaInfo(info);
 

--- a/rpc/block_modify.c
+++ b/rpc/block_modify.c
@@ -466,6 +466,7 @@ block_modify_cli_1_svc_st(blockModifyCli *blk, struct svc_req *rqstp)
   int errCode = -1;
   char *errMsg = NULL;
   blockServerDefPtr list = NULL;
+  char *cmdlog = NULL;
 
 
   LOG("mgmt", GB_LOG_INFO,
@@ -631,8 +632,12 @@ block_modify_cli_1_svc_st(blockModifyCli *blk, struct svc_req *rqstp)
  initfail:
   blockModifyCliFormatResponse (blk, &mobj, asyncret?asyncret:errCode,
                                 errMsg, savereply, info, reply, rollback);
+  if (reply) {
+    cmdlog = gbClipoffSensitiveDetails(reply->out);
+  }
   LOG("cmdlog", ((!!errCode) ? GB_LOG_ERROR : GB_LOG_INFO), "%s",
-      reply ? reply->out : "*Nil*");
+      cmdlog ? cmdlog : "*Nil*");
+  GB_FREE(cmdlog);
   blockFreeMetaInfo(info);
 
   if (savereply) {
@@ -998,9 +1003,8 @@ block_modify_1_svc_st(blockModify *blk, struct svc_req *rqstp)
 
 
   LOG("mgmt", GB_LOG_INFO,
-      "modify request, volume=%s blockname=%s filename=%s authmode=%d passwd=%s",
-      blk->volume, blk->block_name, blk->gbid, blk->auth_mode,
-      blk->auth_mode?blk->passwd:"");
+      "modify request, volume=%s blockname=%s filename=%s authmode=%d",
+      blk->volume, blk->block_name, blk->gbid, blk->auth_mode);
 
   if (GB_ALLOC(reply) < 0) {
     return NULL;

--- a/utils/utils.c
+++ b/utils/utils.c
@@ -643,6 +643,40 @@ out:
 }
 
 
+char *
+gbClipoffSensitiveDetails(char *buf)
+{
+  char *out;
+  char *ptr;
+
+
+  if (!buf) {
+    return NULL;
+  }
+
+  if (GB_STRDUP(out, buf) < 0) {
+    LOG("mgmt", GB_LOG_ERROR,
+        "clipoffSensitiveDetails: failed to strdup (%s)", strerror(errno));
+    return NULL;
+  }
+
+  ptr = strstr(out, "PASSWORD");
+  if (ptr) {
+    ptr = strchr(ptr, ':');
+    /* considering output from plain text, json and json-pretty .. */
+    while (ptr && (*ptr != ',' && *ptr != '\n')) {
+      /* UUID have alphabets, digits and '-' char */
+      if (isalnum(*ptr) || (*ptr == '-')) {
+        *ptr = '*';
+      }
+      ptr++;
+    }
+  }
+
+  return out;
+}
+
+
 int
 initLogging(void)
 {

--- a/utils/utils.h
+++ b/utils/utils.h
@@ -708,6 +708,8 @@ bool gbDependencyVersionCompare(int dependencyName, char *version);
 
 bool glusterBlockSetLogDir(char *logDir);
 
+char *gbClipoffSensitiveDetails(char *buf);
+
 int initLogging(void);
 
 int gbRunnerExitStatus(int exitStatus);


### PR DESCRIPTION
<!--
Thanks for sending a pull request! Your contribution is very much appreciated.

Here are some tips for you:

1. Split the changes up into minimal and atomic commits.
2. Please write a good description about your changes in commit message.
3. Write a meaningful PR text. Remember: one PR per feature or bugfix. If in doubt, split your patchset into multiple PRs.
-->

### What does this PR achieve? Why do we need it?

An information-disclosure flaw was found in the way gluster-block logs
sensitive information. This flaw allows an attacker with access to the
gluster-block logs to read potentially sensitive information, such as
the CHAP passwords for block volumes.

When tuned to debug log-level, gluster-block captutures the targetcli exec
commands output at gluster-blockd.log which might contain sensitive details.
Also block volume create/modify/info cli command outputs might contain
sensitive information, as part of the audit logging these outputs will be
captured at cmd_history.log and gluster-blockd.log 




### Does this PR fix issues?

<!-- This is optional, 'Fixes: #<issue-number>' lines will close the issue if the PR is merged.  -->

Fixes: CVE-2020-10762



