### PR TITLE
delete: fix subsequent delete failures

### DIFF
--- a/rpc/block_delete.c
+++ b/rpc/block_delete.c
@@ -279,12 +279,15 @@ glusterBlockCleanUp(struct glfs *glfs, char *blockname,
   GB_STRCPYSTATIC(dobj.gbid, info->gbid);
 
   count = glusterBlockDeleteFillArgs(info, NULL, NULL, NULL);
-  asyncret = glusterBlockDeleteRemoteAsync(blockname, info, glfs, &dobj, count,
-                                           &drobj);
-  if (asyncret) {
-    LOG("mgmt", GB_LOG_WARNING,
-        "glusterBlockDeleteRemoteAsync: return %d %s for block %s on volume %s",
-        asyncret, FAILED_REMOTE_AYNC_DELETE, blockname, info->volume);
+  /* skip deleting the target config when target nodes count=0 */
+  if (count > 0) {
+    asyncret = glusterBlockDeleteRemoteAsync(blockname, info, glfs, &dobj, count,
+                                             &drobj);
+    if (asyncret) {
+      LOG("mgmt", GB_LOG_WARNING,
+          "glusterBlockDeleteRemoteAsync: return %d %s for block %s on volume %s",
+          asyncret, FAILED_REMOTE_AYNC_DELETE, blockname, info->volume);
+    }
   }
 
   /* delete metafile and block file */


### PR DESCRIPTION
### What does this PR achieve? Why do we need it?

On delete, say the block target config on all the nodes is successfully
deleted, but the backend file couldn't get unlink may due to BHV full space.
In this case the retry of delete fails repeatedly.

Signed-off-by: Prasanna Kumar Kalever <prasanna.kalever@redhat.com>

